### PR TITLE
Add service type filter

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -101,6 +101,14 @@
                         SelectionChanged="FiltersChanged"/>
                         </DockPanel>
 
+                        <!-- Tipo Serviço -->
+                        <DockPanel>
+                            <TextBlock Text="Tipo Serviço:" Style="{StaticResource LabelText}"/>
+                            <ComboBox x:Name="TipoFilterCombo"
+                        Style="{StaticResource InputControl}"
+                        SelectionChanged="FiltersChanged"/>
+                        </DockPanel>
+
                         <!-- NumOS -->
                         <DockPanel>
                             <TextBlock Text="NumOS:" Style="{StaticResource LabelText}"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -30,6 +30,7 @@ namespace ManutMap
 
             // associa eventos de filtro
             SigfiFilterCombo.SelectionChanged += FiltersChanged;
+            TipoFilterCombo.SelectionChanged += FiltersChanged;
             NumOsFilterBox.TextChanged += FiltersChanged;
             IdSigfiFilterBox.TextChanged += FiltersChanged;
             RotaFilterBox.TextChanged += FiltersChanged;
@@ -50,6 +51,7 @@ namespace ManutMap
             _manutList = _fileService.LoadLocalJson(path) ?? new JArray();
 
             PopulateSigfiCombo();
+            PopulateTipoCombo();
             ApplyFilters();
         }
 
@@ -69,11 +71,28 @@ namespace ManutMap
             SigfiFilterCombo.SelectedIndex = 0;
         }
 
+        private void PopulateTipoCombo()
+        {
+            var tipos = _manutList
+                .OfType<JObject>()
+                .Select(o => o["TIPO"]?.ToString().Trim())
+                .Where(s => !string.IsNullOrEmpty(s))
+                .Distinct()
+                .OrderBy(s => s);
+
+            TipoFilterCombo.Items.Clear();
+            TipoFilterCombo.Items.Add(new ComboBoxItem { Content = "Todos" });
+            foreach (var t in tipos)
+                TipoFilterCombo.Items.Add(new ComboBoxItem { Content = t });
+            TipoFilterCombo.SelectedIndex = 0;
+        }
+
         private async void DownloadButton_Click(object sender, RoutedEventArgs e)
         {
             DownloadButton.IsEnabled = false;
             _manutList = await _spService.DownloadLatestJsonAsync();
             PopulateSigfiCombo();
+            PopulateTipoCombo();
             ApplyFilters();
             DownloadButton.IsEnabled = true;
         }
@@ -90,6 +109,7 @@ namespace ManutMap
             var criteria = new FilterCriteria
             {
                 Sigfi = (SigfiFilterCombo.SelectedItem as ComboBoxItem)?.Content.ToString() ?? "Todos",
+                TipoServico = (TipoFilterCombo.SelectedItem as ComboBoxItem)?.Content.ToString() ?? "Todos",
                 NumOs = NumOsFilterBox.Text.Trim(),
                 IdSigfi = IdSigfiFilterBox.Text.Trim(),
                 Rota = RotaFilterBox.Text.Trim(),

--- a/Models/FilterCriteria.cs
+++ b/Models/FilterCriteria.cs
@@ -8,6 +8,7 @@ namespace ManutMap.Models
         public string NumOs { get; set; }
         public string IdSigfi { get; set; }
         public string Rota { get; set; }
+        public string TipoServico { get; set; } = "Todos";
 
         public DateTime? StartDate { get; set; }
         public DateTime? EndDate { get; set; }

--- a/Services/FilterService.cs
+++ b/Services/FilterService.cs
@@ -29,6 +29,10 @@ namespace ManutMap.Services
                         item["ROTA"]?.ToString()
                              .IndexOf(c.Rota, StringComparison.OrdinalIgnoreCase) < 0)
                         return false;
+                    if (c.TipoServico != "Todos" &&
+                        !item["TIPO"]?.ToString().Trim()
+                             .Equals(c.TipoServico, StringComparison.OrdinalIgnoreCase) == true)
+                        return false;
 
                     var dtRec = item["DTAHORARECLAMACAO"]?.ToString();
                     var dtCon = item["DTCONCLUSAO"]?.ToString();


### PR DESCRIPTION
## Summary
- add `TipoServico` field to filter criteria
- include service type filtering logic
- update UI with new combo box for tipo de serviço
- populate service type options from JSON

## Testing
- `dotnet build -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644a2207708333aa47c3d208ff48c9