### PR TITLE
Fix missing XAML resources

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -18,6 +18,18 @@
             <Setter Property="Cursor" Value="Hand"/>
             <Setter Property="BorderThickness" Value="0"/>
         </Style>
+        <!-- Style for labels inside filter panels -->
+        <Style x:Key="LabelText" TargetType="TextBlock">
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Margin" Value="0 0 5 0"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+        </Style>
+
+        <!-- Style applied to input controls like ComboBox -->
+        <Style x:Key="InputControl" TargetType="ComboBox">
+            <Setter Property="Margin" Value="0 0 0 15"/>
+            <Setter Property="MinWidth" Value="150"/>
+        </Style>
     </Window.Resources>
 
     <DockPanel>


### PR DESCRIPTION
## Summary
- add style resources for `LabelText` and `InputControl` in `MainWindow.xaml`

## Testing
- `dotnet build ManutMap.sln` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644c8be3788333945dcaae54587526