### PR TITLE
Fix lat/lon parsing for LATLONCON

### DIFF
--- a/Helpers/MapHtmlHelper.cs
+++ b/Helpers/MapHtmlHelper.cs
@@ -42,9 +42,12 @@
         if (!coord || coord.trim() === '') return;
 
         var coordStr = coord.trim();
-        var parts = coordStr.split(',');
-        var lat = parseFloat(parts[0]), lng = parseFloat(parts[1]);
-        if(isNaN(lat)||isNaN(lng))return;
+        // tenta extrair dois numeros, tolerando diferentes formatos
+        var nums = coordStr.match(/-?\d+(?:[.,]\d+)?/g);
+        if(!nums || nums.length < 2) return;
+        var lat = parseFloat(nums[0].replace(',', '.')),
+            lng = parseFloat(nums[1].replace(',', '.'));
+        if(isNaN(lat) || isNaN(lng)) return;
         var color = isOpen?colorOpen:colorClosed;
 
         var m = L.circleMarker([lat,lng],{


### PR DESCRIPTION
## Summary
- handle LATLONCON coordinates that use various separators and decimal formats

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68644f94956c833393115ffc6a1fd272