### PR TITLE
Update rota filter to combo

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -88,7 +88,7 @@
 
                         <!-- Rota -->
                         <TextBlock Text="Rota:" FontWeight="SemiBold"/>
-                        <TextBox x:Name="RotaFilterBox" TextChanged="FiltersChanged" Margin="0 0 0 15"/>
+                        <ComboBox x:Name="RotaFilterCombo" SelectionChanged="FiltersChanged" Margin="0 0 0 15"/>
 
                         <!-- Período -->
                         <TextBlock Text="Período:" FontWeight="SemiBold"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -33,7 +33,7 @@ namespace ManutMap
             TipoFilterCombo.SelectionChanged += FiltersChanged;
             NumOsFilterBox.TextChanged += FiltersChanged;
             IdSigfiFilterBox.TextChanged += FiltersChanged;
-            RotaFilterBox.TextChanged += FiltersChanged;
+            RotaFilterCombo.SelectionChanged += FiltersChanged;
             StartDatePicker.SelectedDateChanged += FiltersChanged;
             EndDatePicker.SelectedDateChanged += FiltersChanged;
             ChbOpen.Checked += FiltersChanged;
@@ -52,6 +52,7 @@ namespace ManutMap
 
             PopulateSigfiCombo();
             PopulateTipoCombo();
+            PopulateRotaCombo();
             ApplyFilters();
         }
 
@@ -87,12 +88,29 @@ namespace ManutMap
             TipoFilterCombo.SelectedIndex = 0;
         }
 
+        private void PopulateRotaCombo()
+        {
+            var rotas = _manutList
+                .OfType<JObject>()
+                .Select(o => o["ROTA"]?.ToString().Trim())
+                .Where(s => !string.IsNullOrEmpty(s))
+                .Distinct()
+                .OrderBy(s => s);
+
+            RotaFilterCombo.Items.Clear();
+            RotaFilterCombo.Items.Add(new ComboBoxItem { Content = "Todos" });
+            foreach (var r in rotas)
+                RotaFilterCombo.Items.Add(new ComboBoxItem { Content = r });
+            RotaFilterCombo.SelectedIndex = 0;
+        }
+
         private async void DownloadButton_Click(object sender, RoutedEventArgs e)
         {
             DownloadButton.IsEnabled = false;
             _manutList = await _spService.DownloadLatestJsonAsync();
             PopulateSigfiCombo();
             PopulateTipoCombo();
+            PopulateRotaCombo();
             ApplyFilters();
             DownloadButton.IsEnabled = true;
         }
@@ -112,7 +130,7 @@ namespace ManutMap
                 TipoServico = (TipoFilterCombo.SelectedItem as ComboBoxItem)?.Content.ToString() ?? "Todos",
                 NumOs = NumOsFilterBox.Text.Trim(),
                 IdSigfi = IdSigfiFilterBox.Text.Trim(),
-                Rota = RotaFilterBox.Text.Trim(),
+                Rota = (RotaFilterCombo.SelectedItem as ComboBoxItem)?.Content.ToString() ?? "Todos",
                 StartDate = StartDatePicker.SelectedDate,
                 EndDate = EndDatePicker.SelectedDate,
                 ShowOpen = ChbOpen.IsChecked == true,

--- a/Models/FilterCriteria.cs
+++ b/Models/FilterCriteria.cs
@@ -7,7 +7,7 @@ namespace ManutMap.Models
         public string Sigfi { get; set; } = "Todos";
         public string NumOs { get; set; }
         public string IdSigfi { get; set; }
-        public string Rota { get; set; }
+        public string Rota { get; set; } = "Todos";
         public string TipoServico { get; set; } = "Todos";
 
         public DateTime? StartDate { get; set; }

--- a/Services/FilterService.cs
+++ b/Services/FilterService.cs
@@ -31,10 +31,10 @@ namespace ManutMap.Services
                         if (idSigfi.IndexOf(c.IdSigfi, StringComparison.OrdinalIgnoreCase) < 0)
                             return false;
                     }
-                    if (!string.IsNullOrEmpty(c.Rota))
+                    if (c.Rota != "Todos")
                     {
-                        var rota = item["ROTA"]?.ToString() ?? string.Empty;
-                        if (rota.IndexOf(c.Rota, StringComparison.OrdinalIgnoreCase) < 0)
+                        var rota = (item["ROTA"]?.ToString() ?? string.Empty).Trim();
+                        if (!rota.Equals(c.Rota, StringComparison.OrdinalIgnoreCase))
                             return false;
                     }
                     if (c.TipoServico != "Todos")


### PR DESCRIPTION
## Summary
- make `Rota` filter a combo box instead of a text box
- update filtering logic to check equality when a route is chosen
- provide methods to populate the new combo box
- default `Rota` filter criteria to `Todos`

## Testing
- `dotnet build ManutMap.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686456c5b6648333b957f14a278c9607