### PR TITLE
Exibe contadores de manutenção

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -92,7 +92,14 @@
 
         <!-- MAPA -->
         <Grid Grid.Column="1">
-            <wv2:WebView2 x:Name="MapView" />
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <TextBlock x:Name="StatsTextBlock"
+                       Margin="10"
+                       FontWeight="Bold"/>
+            <wv2:WebView2 x:Name="MapView" Grid.Row="1" />
         </Grid>
     </Grid>
 </Window>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -151,6 +151,38 @@ namespace ManutMap
                 criteria.ColorClosed,
                 criteria.LatLonField
             );
+
+            // calcula estatísticas básicas para exibir no painel
+            int prevAbertas = 0,
+                prevConcluidas = 0,
+                corrConcluidas = 0;
+
+            foreach (var item in result)
+            {
+                var tipo = item["TIPODESIGFI"]?.ToString().Trim().ToLowerInvariant();
+                var dtRec = item["DTAHORARECLAMACAO"]?.ToString();
+                var dtCon = item["DTCONCLUSAO"]?.ToString();
+                bool isOpen = !string.IsNullOrWhiteSpace(dtRec) && string.IsNullOrWhiteSpace(dtCon);
+                bool isClosed = !string.IsNullOrWhiteSpace(dtCon);
+
+                if (tipo == "preventiva")
+                {
+                    if (isOpen) prevAbertas++;
+                    if (isClosed) prevConcluidas++;
+                }
+                else if (tipo == "corretiva")
+                {
+                    if (isClosed) corrConcluidas++;
+                }
+            }
+
+            int totalServicos = result.Count;
+
+            StatsTextBlock.Text =
+                $"Preventivas abertas: {prevAbertas} / " +
+                $"Preventivas concluídas: {prevConcluidas} / " +
+                $"Corretivas concluídas: {corrConcluidas} / " +
+                $"Serviços: {totalServicos}";
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a stats block above the map
- compute basic maintenance stats whenever filters apply

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68645e78c2248333bc0a8fd9631eb765