### PR TITLE
Add concluded services count to stats

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -155,7 +155,8 @@ namespace ManutMap
             // calcula estatísticas básicas para exibir no painel
             int prevAbertas = 0,
                 prevConcluidas = 0,
-                corrConcluidas = 0;
+                corrConcluidas = 0,
+                servConcluidos = 0;
 
             foreach (var item in result)
             {
@@ -164,6 +165,9 @@ namespace ManutMap
                 var dtCon = item["DTCONCLUSAO"]?.ToString();
                 bool isOpen = !string.IsNullOrWhiteSpace(dtRec) && string.IsNullOrWhiteSpace(dtCon);
                 bool isClosed = !string.IsNullOrWhiteSpace(dtCon);
+
+                if (isClosed)
+                    servConcluidos++;
 
                 if (tipo == "preventiva")
                 {
@@ -182,6 +186,7 @@ namespace ManutMap
                 $"Preventivas abertas: {prevAbertas} / " +
                 $"Preventivas concluídas: {prevConcluidas} / " +
                 $"Corretivas concluídas: {corrConcluidas} / " +
+                $"Serviços concluídos: {servConcluidos} / " +
                 $"Serviços: {totalServicos}";
         }
     }


### PR DESCRIPTION
## Summary
- show a new counter for total concluded services in the statistics text block

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68646255c8788333b0375b190f240d77