### PR TITLE
Enable custom coloring by maintenance type

### DIFF
--- a/Helpers/MapHtmlHelper.cs
+++ b/Helpers/MapHtmlHelper.cs
@@ -80,6 +80,59 @@
         map.fitBounds(grp.getBounds().pad(0.2));
       }
     }
+
+    function addMarkersByTipoSigfi(data, showOpen, showClosed, colorPrev, colorCorr, latLonField){
+      clearMarkers();
+
+      data.forEach(function(item){
+        var dtRec = item.DTAHORARECLAMACAO ? item.DTAHORARECLAMACAO.trim() : '';
+        var dtCon = item.DTCONCLUSAO     ? item.DTCONCLUSAO.trim()     : '';
+        var isOpen   = dtRec !== '' && dtCon === '';
+        var isClosed = dtCon !== '';
+        if((isOpen && !showOpen) || (isClosed && !showClosed)) return;
+
+        var coord = null;
+        if(latLonField === 'LATLON')
+          coord = item.LATLON;
+        else if(latLonField === 'LATLONCON')
+          coord = item.LATLONCON;
+        if(!coord || coord.trim() === '') return;
+
+        var coordStr = coord.trim();
+        var nums = coordStr.match(/-?\d+(?:[.,]\d+)?/g);
+        if(!nums || nums.length < 2) return;
+        var lat = parseFloat(nums[0].replace(',', '.')),
+            lng = parseFloat(nums[1].replace(',', '.'));
+        if(isNaN(lat) || isNaN(lng)) return;
+
+        var tipo = (item.TIPODESIGFI || '').toString().trim().toLowerCase();
+        var color = tipo === 'preventiva' ? colorPrev :
+                    tipo === 'corretiva' ? colorCorr : colorPrev;
+
+        var m = L.circleMarker([lat,lng],{
+          radius:6, fillColor:color, color:'#fff', weight:1.2, fillOpacity:0.9
+        }).addTo(map);
+
+        var popup = '<b>OS:</b> '+item.NUMOS+'<br>'+
+                    '<b>Cliente:</b> '+item.NOMECLIENTE+'<br>'+
+                    (isOpen?'<b>Status:</b> <span style="'+'color:'+color+'"'+'>Aberto</span><br>'
+                           :'<b>Status:</b> <span style="'+'color:'+color+'"'+'>Concluído</span><br>')+
+                    (dtRec?'<b>Abertura:</b> '+dtRec+'<br>':'')+
+                    (dtCon?'<b>Conclusão:</b> '+dtCon+'<br>':'')+
+                    '<b>Rota:</b> '+item.ROTA+'<br>'+
+                    '<b>Tipo SIGFI:</b> '+item.TIPODESIGFI+'<br>'+
+                    '<b>IDSIGFI:</b> '+item.IDSIGFI+'<br>'+
+                    '<b>Serviço:</b> '+item.TIPO+'<br>'+
+                    '<b>LatLon ('+latLonField+'):</b> '+coordStr;
+
+        m.bindPopup(popup);
+        markers.push(m);
+      });
+      if(markers.length>0){
+        var grp = L.featureGroup(markers);
+        map.fitBounds(grp.getBounds().pad(0.2));
+      }
+    }
   </script>
 </body></html>";
     }

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -77,6 +77,12 @@
                     <CheckBox x:Name="ChbClosed" Content="Concluído" IsChecked="True" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
                     <TextBox x:Name="TxtColorClosed" Width="100" Margin="0 0 0 8" Text="#008000"/>
 
+                    <CheckBox x:Name="ChbColorBySigfi" Content="Colorir por Tipo SIGFI" Margin="0 8 0 0" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
+                    <TextBlock Text="Cor Preventiva:"/>
+                    <TextBox x:Name="TxtColorPrev" Width="100" Margin="0 0 0 8" Text="#0000FF"/>
+                    <TextBlock Text="Cor Corretiva:"/>
+                    <TextBox x:Name="TxtColorCorr" Width="100" Margin="0 0 0 8" Text="#FFA500"/>
+
                     <!-- Seção de Configurações -->
                     <TextBlock Text="Configurações" Style="{StaticResource SectionTitle}"/>
                     <TextBlock Text="Campo Coordenada:"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -42,6 +42,10 @@ namespace ManutMap
             ChbClosed.Unchecked += FiltersChanged;
             TxtColorOpen.TextChanged += FiltersChanged;
             TxtColorClosed.TextChanged += FiltersChanged;
+            ChbColorBySigfi.Checked += FiltersChanged;
+            ChbColorBySigfi.Unchecked += FiltersChanged;
+            TxtColorPrev.TextChanged += FiltersChanged;
+            TxtColorCorr.TextChanged += FiltersChanged;
         }
 
         private void LoadLocalAndPopulate()
@@ -137,20 +141,37 @@ namespace ManutMap
                 ShowClosed = ChbClosed.IsChecked == true,
                 ColorOpen = TxtColorOpen.Text.Trim(),
                 ColorClosed = TxtColorClosed.Text.Trim(),
+                ColorByTipoSigfi = ChbColorBySigfi.IsChecked == true,
+                ColorPreventiva = TxtColorPrev.Text.Trim(),
+                ColorCorretiva = TxtColorCorr.Text.Trim(),
 
                         LatLonField = (LatLonFieldCombo.SelectedItem as ComboBoxItem)?.Content?.ToString()
                         ?? "LATLON"
             };
 
             var result = _filterSvc.Apply(_manutList, criteria);
-            _mapService.AddMarkers(
-                result,
-                criteria.ShowOpen,
-                criteria.ShowClosed,
-                criteria.ColorOpen,
-                criteria.ColorClosed,
-                criteria.LatLonField
-            );
+            if (criteria.ColorByTipoSigfi)
+            {
+                _mapService.AddMarkersByTipoSigfi(
+                    result,
+                    criteria.ShowOpen,
+                    criteria.ShowClosed,
+                    criteria.ColorPreventiva,
+                    criteria.ColorCorretiva,
+                    criteria.LatLonField
+                );
+            }
+            else
+            {
+                _mapService.AddMarkers(
+                    result,
+                    criteria.ShowOpen,
+                    criteria.ShowClosed,
+                    criteria.ColorOpen,
+                    criteria.ColorClosed,
+                    criteria.LatLonField
+                );
+            }
 
             // calcula estatísticas básicas para exibir no painel
             int prevAbertas = 0,

--- a/Models/FilterCriteria.cs
+++ b/Models/FilterCriteria.cs
@@ -19,6 +19,11 @@ namespace ManutMap.Models
         public string ColorOpen { get; set; } = "#FF0000";
         public string ColorClosed { get; set; } = "#008000";
 
+        // Se true, usa cores baseadas no Tipo SIGFI
+        public bool ColorByTipoSigfi { get; set; }
+        public string ColorPreventiva { get; set; } = "#0000FF";
+        public string ColorCorretiva { get; set; } = "#FFA500";
+
         // NOVO: qual campo de coordenada usar
         // "LATLON" ou "LATLONCON"
         public string LatLonField { get; set; } = "LATLON";

--- a/Services/MapService.cs
+++ b/Services/MapService.cs
@@ -49,5 +49,23 @@ namespace ManutMap.Services
             else
                 _view.ExecuteScriptAsync(script);
         }
+
+        public void AddMarkersByTipoSigfi(IEnumerable<JObject> data,
+                                           bool showOpen,
+                                           bool showClosed,
+                                           string colorPrev,
+                                           string colorCorr,
+                                           string latLonField = "LATLON")
+        {
+            var json = JsonConvert.SerializeObject(data);
+            var script =
+                $"addMarkersByTipoSigfi({json},{showOpen.ToString().ToLower()},{showClosed.ToString().ToLower()}," +
+                $"'{colorPrev}','{colorCorr}','{latLonField}');";
+
+            if (!_ready)
+                _pendingScripts.Add(script);
+            else
+                _view.ExecuteScriptAsync(script);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add color configuration for preventive and corrective filters
- support choosing between color by status or by maintenance type
- implement `addMarkersByTipoSigfi` in map HTML helper
- extend `MapService` with `AddMarkersByTipoSigfi`
- update UI and filtering logic to handle new color options

## Testing
- `dotnet build ManutMap.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686462a779448333a18e9ed65345bb46