### PR TITLE
Improve maintenance stats panel

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -103,7 +103,8 @@
             </Grid.RowDefinitions>
             <TextBlock x:Name="StatsTextBlock"
                        Margin="10"
-                       FontWeight="Bold"/>
+                       FontWeight="Bold"
+                       TextWrapping="Wrap"/>
             <wv2:WebView2 x:Name="MapView" Grid.Row="1" />
         </Grid>
     </Grid>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -155,6 +155,7 @@ namespace ManutMap
             // calcula estatísticas básicas para exibir no painel
             int prevAbertas = 0,
                 prevConcluidas = 0,
+                corrAbertas = 0,
                 corrConcluidas = 0,
                 servConcluidos = 0;
 
@@ -176,6 +177,7 @@ namespace ManutMap
                 }
                 else if (tipo == "corretiva")
                 {
+                    if (isOpen) corrAbertas++;
                     if (isClosed) corrConcluidas++;
                 }
             }
@@ -183,11 +185,12 @@ namespace ManutMap
             int totalServicos = result.Count;
 
             StatsTextBlock.Text =
-                $"Preventivas abertas: {prevAbertas} / " +
-                $"Preventivas concluídas: {prevConcluidas} / " +
-                $"Corretivas concluídas: {corrConcluidas} / " +
-                $"Serviços concluídos: {servConcluidos} / " +
-                $"Serviços: {totalServicos}";
+                $"Preventivas abertas: {prevAbertas}\n" +
+                $"Corretivas abertas: {corrAbertas}\n" +
+                $"Preventivas concluídas: {prevConcluidas}\n" +
+                $"Corretivas concluídas: {corrConcluidas}\n" +
+                $"Serviços concluídos: {servConcluidos}\n" +
+                $"Total de serviços: {totalServicos}";
         }
     }
 }


### PR DESCRIPTION
## Summary
- count open corrective tasks
- show more organized multi-line stats text
- allow stats text to wrap by default

## Testing
- `dotnet build ManutMap.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686463a18040833386558458c21e3450