### PR TITLE
Add Regional filter combobox

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -117,6 +117,9 @@
                                 <TextBlock Text="ID SIGFI" Style="{StaticResource LabelTextBlock}" Margin="0,10,0,5"/>
                                 <TextBox x:Name="IdSigfiFilterBox" TextChanged="FiltersChanged"/>
 
+                                <TextBlock Text="Regional" Style="{StaticResource LabelTextBlock}" Margin="0,10,0,5"/>
+                                <ComboBox x:Name="RegionalFilterCombo" SelectionChanged="RegionalChanged"/>
+
                                 <TextBlock Text="Rota" Style="{StaticResource LabelTextBlock}" Margin="0,10,0,5"/>
                                 <ComboBox x:Name="RotaFilterCombo" SelectionChanged="FiltersChanged"/>
                             </StackPanel>

--- a/Models/FilterCriteria.cs
+++ b/Models/FilterCriteria.cs
@@ -7,6 +7,7 @@ namespace ManutMap.Models
         public string Sigfi { get; set; } = "Todos";
         public string NumOs { get; set; }
         public string IdSigfi { get; set; }
+        public string Regional { get; set; } = "Todos";
         public string Rota { get; set; } = "Todos";
         public string TipoServico { get; set; } = "Todos";
 

--- a/Services/FilterService.cs
+++ b/Services/FilterService.cs
@@ -8,6 +8,13 @@ namespace ManutMap.Services
 {
     public class FilterService
     {
+        private readonly Dictionary<string, List<string>> _regionalRotas = new()
+        {
+            {"Cruzeiro do Sul", new List<string>{"01","02","03","04","05","14","15","16","17","30","32","34","36","39","40","42","06"}},
+            {"Tarauacá", new List<string>{"07","08","09","10","21","22","23","24","33","38","37","50","51","66","67","71"}},
+            {"Sena Madureira", new List<string>{"11","12","52","54","55","57","58","59","63","65"}}
+        };
+
         public List<JObject> Apply(JArray source, FilterCriteria c)
         {
             return source.OfType<JObject>()
@@ -31,9 +38,14 @@ namespace ManutMap.Services
                         if (idSigfi.IndexOf(c.IdSigfi, StringComparison.OrdinalIgnoreCase) < 0)
                             return false;
                     }
+                    var rota = (item["ROTA"]?.ToString() ?? string.Empty).Trim();
+                    if (c.Regional != "Todos")
+                    {
+                        if (!_regionalRotas.TryGetValue(c.Regional, out var rotas) || !rotas.Contains(rota))
+                            return false;
+                    }
                     if (c.Rota != "Todos")
                     {
-                        var rota = (item["ROTA"]?.ToString() ?? string.Empty).Trim();
                         if (!rota.Equals(c.Rota, StringComparison.OrdinalIgnoreCase))
                             return false;
                     }


### PR DESCRIPTION
## Summary
- add Regional property to filtering criteria
- dynamically populate Regional combobox and update Rota list when region changes
- filter services based on Regional -> Rota mapping

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865390d4cfc8333aa6454614ace26a4