### PR TITLE
Enable automatic JSON download at startup

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -50,9 +50,10 @@ namespace ManutMap
             _mapService = new MapService(MapView);
             _mapService.InitializeAsync();
 
-            this.Loaded += (_, __) =>
+            this.Loaded += async (_, __) =>
             {
                 LoadLocalAndPopulate();
+                await DownloadAndRefresh();
                 _updateTimer.Start();
             };
 


### PR DESCRIPTION
## Summary
- trigger initial data refresh on application startup before starting the 30‑minute timer

## Testing
- `dotnet build ManutMap.sln -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68654a11a9cc8333af955c8d5b0f76aa