### PR TITLE
Fix toggle button visibility

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -199,8 +199,12 @@
             </Grid.RowDefinitions>
 
             <Grid Grid.Row="0">
-                <wv2:WebView2 x:Name="MapView" />
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
                 <Button x:Name="ToggleSidebarButton" Content="◄" Width="25" Height="40" Margin="5" HorizontalAlignment="Left" VerticalAlignment="Top" Click="ToggleSidebarButton_Click" />
+                <wv2:WebView2 x:Name="MapView" Grid.Column="1" />
             </Grid>
 
             <Border Grid.Row="1" 


### PR DESCRIPTION
## Summary
- show the sidebar toggle button by placing it in its own column

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686550e71d808333a4a1f18a9191a464