### PR TITLE
Add CSV export to share feature

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Windows;
 using System.Threading.Tasks;
 using System.Windows.Controls;
+using Microsoft.Win32;
 using System.Windows.Threading;
 using Newtonsoft.Json.Linq;
 using ManutMap.Models;
@@ -254,6 +255,17 @@ namespace ManutMap
 
             var criteria = GetCurrentCriteria();
             var filtered = _filterSvc.Apply(_manutList, criteria);
+
+            var dialog = new SaveFileDialog
+            {
+                Filter = "CSV Files (*.csv)|*.csv",
+                FileName = $"manutencoes_{DateTime.Now:yyyyMMddHHmmss}.csv",
+                DefaultExt = "csv"
+            };
+            if (dialog.ShowDialog() == true)
+            {
+                _fileService.SaveCsv(filtered, dialog.FileName, criteria.LatLonField);
+            }
             var html = Helpers.MapHtmlHelper.GetHtmlWithData(filtered,
                                                             criteria.ColorByTipoSigfi,
                                                             criteria.ShowOpen,

--- a/Services/FileService.cs
+++ b/Services/FileService.cs
@@ -1,4 +1,8 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json.Linq;
 
 namespace ManutMap.Services
@@ -11,6 +15,46 @@ namespace ManutMap.Services
             var json = File.ReadAllText(filename);
             var root = JObject.Parse(json);
             return (JArray)root["manutencoes"];
+        }
+
+        public void SaveCsv(IEnumerable<JObject> data, string path, string latLonField = "LATLON")
+        {
+            if (data == null) return;
+
+            var headers = new SortedSet<string>(data.SelectMany(o => o.Properties().Select(p => p.Name)));
+            headers.Remove(latLonField);
+
+            var sb = new StringBuilder();
+            sb.AppendLine(string.Join(",", headers) + ",Latitude,Longitude");
+
+            foreach (var obj in data)
+            {
+                string lat = string.Empty, lon = string.Empty;
+                var coord = obj[latLonField]?.ToString();
+                if (!string.IsNullOrWhiteSpace(coord))
+                {
+                    var m = Regex.Matches(coord, "-?\\d+(?:[.,]\\d+)?");
+                    if (m.Count >= 2)
+                    {
+                        lat = m[0].Value.Replace(',', '.');
+                        lon = m[1].Value.Replace(',', '.');
+                    }
+                }
+
+                var values = headers.Select(h => EscapeCsv(obj[h]?.ToString()));
+                sb.AppendLine(string.Join(",", values) + $",{EscapeCsv(lat)},{EscapeCsv(lon)}");
+            }
+
+            File.WriteAllText(path, sb.ToString(), Encoding.UTF8);
+        }
+
+        private static string EscapeCsv(string value)
+        {
+            if (value == null) return string.Empty;
+            if (value.Contains("\"")) value = value.Replace("\"", "\"\"");
+            if (value.Contains(",") || value.Contains("\n") || value.Contains("\r"))
+                return $"\"{value}\"";
+            return value;
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend `FileService` with CSV exporting helper
- allow Share button to save filtered data as a CSV before uploading map

## Testing
- `dotnet build ManutMap.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68667ba073a48333a51c0baba4f0db5d