### PR TITLE
Add service type coloring

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -175,6 +175,20 @@
                                     </StackPanel>
                                 </GroupBox>
 
+                                <GroupBox Header="Colorir por Tipo de Serviço">
+                                    <StackPanel Margin="10,5,0,0">
+                                        <CheckBox x:Name="ChbColorByTipo" Content="Ativar Coloração por Serviço" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
+                                        <TextBlock Text="Cor Preventiva:" Style="{StaticResource LabelTextBlock}" Margin="10,5,0,2"/>
+                                        <TextBox x:Name="TxtColorTipoPrev" Width="100" Margin="10,0,0,5" Text="#0000FF"/>
+
+                                        <TextBlock Text="Cor Corretiva:" Style="{StaticResource LabelTextBlock}" Margin="10,5,0,2"/>
+                                        <TextBox x:Name="TxtColorTipoCorr" Width="100" Margin="10,0,0,5" Text="#FFA500"/>
+
+                                        <TextBlock Text="Cor Serviços:" Style="{StaticResource LabelTextBlock}" Margin="10,5,0,2"/>
+                                        <TextBox x:Name="TxtColorTipoServ" Width="100" Margin="10,0,0,0" Text="#008080"/>
+                                    </StackPanel>
+                                </GroupBox>
+
                                 <GroupBox Header="Campo de Coordenadas">
                                     <StackPanel Margin="10,5,0,0">
                                         <TextBlock Text="Selecione o campo com coordenadas:" Style="{StaticResource LabelTextBlock}"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -77,6 +77,11 @@ namespace ManutMap
             ChbColorBySigfi.Unchecked += FiltersChanged;
             TxtColorPrev.TextChanged += FiltersChanged;
             TxtColorCorr.TextChanged += FiltersChanged;
+            ChbColorByTipo.Checked += FiltersChanged;
+            ChbColorByTipo.Unchecked += FiltersChanged;
+            TxtColorTipoPrev.TextChanged += FiltersChanged;
+            TxtColorTipoCorr.TextChanged += FiltersChanged;
+            TxtColorTipoServ.TextChanged += FiltersChanged;
         }
 
         private void LoadLocalAndPopulate()
@@ -177,6 +182,10 @@ namespace ManutMap
                 ColorByTipoSigfi = ChbColorBySigfi.IsChecked == true,
                 ColorPreventiva = TxtColorPrev.Text.Trim(),
                 ColorCorretiva = TxtColorCorr.Text.Trim(),
+                ColorByTipoServico = ChbColorByTipo.IsChecked == true,
+                ColorServicoPreventiva = TxtColorTipoPrev.Text.Trim(),
+                ColorServicoCorretiva = TxtColorTipoCorr.Text.Trim(),
+                ColorServicoOutros = TxtColorTipoServ.Text.Trim(),
                 LatLonField = (LatLonFieldCombo.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? "LATLON"
             };
         }
@@ -203,7 +212,17 @@ namespace ManutMap
 
             var filteredResult = _filterSvc.Apply(_manutList, criteria);
 
-            if (criteria.ColorByTipoSigfi)
+            if (criteria.ColorByTipoServico)
+            {
+                _mapService.AddMarkersByTipoServico(filteredResult,
+                                                   criteria.ShowOpen,
+                                                   criteria.ShowClosed,
+                                                   criteria.ColorServicoPreventiva,
+                                                   criteria.ColorServicoCorretiva,
+                                                   criteria.ColorServicoOutros,
+                                                   criteria.LatLonField);
+            }
+            else if (criteria.ColorByTipoSigfi)
             {
                 _mapService.AddMarkersByTipoSigfi(filteredResult, criteria.ShowOpen, criteria.ShowClosed, criteria.ColorPreventiva, criteria.ColorCorretiva, criteria.LatLonField);
             }
@@ -256,12 +275,14 @@ namespace ManutMap
             var filtered = _filterSvc.Apply(_manutList, criteria);
             var html = Helpers.MapHtmlHelper.GetHtmlWithData(filtered,
                                                             criteria.ColorByTipoSigfi,
+                                                            criteria.ColorByTipoServico,
                                                             criteria.ShowOpen,
                                                             criteria.ShowClosed,
                                                             criteria.ColorOpen,
                                                             criteria.ColorClosed,
-                                                            criteria.ColorPreventiva,
-                                                            criteria.ColorCorretiva,
+                                                            criteria.ColorByTipoServico ? criteria.ColorServicoPreventiva : criteria.ColorPreventiva,
+                                                            criteria.ColorByTipoServico ? criteria.ColorServicoCorretiva : criteria.ColorCorretiva,
+                                                            criteria.ColorServicoOutros,
                                                             criteria.LatLonField);
 
             var fileName = $"mapa_{DateTime.Now:yyyyMMddHHmmss}.html";

--- a/Models/FilterCriteria.cs
+++ b/Models/FilterCriteria.cs
@@ -25,6 +25,12 @@ namespace ManutMap.Models
         public string ColorPreventiva { get; set; } = "#0000FF";
         public string ColorCorretiva { get; set; } = "#FFA500";
 
+        // Cores por tipo de serviço (Preventiva/Corretiva/Serviços)
+        public bool ColorByTipoServico { get; set; }
+        public string ColorServicoPreventiva { get; set; } = "#0000FF";
+        public string ColorServicoCorretiva { get; set; } = "#FFA500";
+        public string ColorServicoOutros { get; set; } = "#008080";
+
         // NOVO: qual campo de coordenada usar
         // "LATLON" ou "LATLONCON"
         public string LatLonField { get; set; } = "LATLON";

--- a/Services/MapService.cs
+++ b/Services/MapService.cs
@@ -67,5 +67,24 @@ namespace ManutMap.Services
             else
                 _view.ExecuteScriptAsync(script);
         }
+
+        public void AddMarkersByTipoServico(IEnumerable<JObject> data,
+                                           bool showOpen,
+                                           bool showClosed,
+                                           string colorPrev,
+                                           string colorCorr,
+                                           string colorServ,
+                                           string latLonField = "LATLON")
+        {
+            var json = JsonConvert.SerializeObject(data);
+            var script =
+                $"addMarkersByTipoServico({json},{showOpen.ToString().ToLower()},{showClosed.ToString().ToLower()}," +
+                $"'{colorPrev}','{colorCorr}','{colorServ}','{latLonField}');";
+
+            if (!_ready)
+                _pendingScripts.Add(script);
+            else
+                _view.ExecuteScriptAsync(script);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- support markers colored by service type (Preventiva, Corretiva, Servicos)
- expose new settings in UI to toggle service-type colours
- expand FilterCriteria and MapService for new options
- update HTML helper with JS to colour markers by TIPO

## Testing
- `dotnet build ManutMap.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68667b7cd4708333a9368857248a7429