### PR TITLE
Add per-job-type map markers

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -215,13 +215,10 @@ namespace ManutMap
 
             if (criteria.ColorByTipoServico)
             {
-                _mapService.AddMarkersByTipoServico(filteredResult,
-                                                   criteria.ShowOpen,
-                                                   criteria.ShowClosed,
-                                                   criteria.ColorServicoPreventiva,
-                                                   criteria.ColorServicoCorretiva,
-                                                   criteria.ColorServicoOutros,
-                                                   criteria.LatLonField);
+                _mapService.AddMarkersByTipoServicoIcon(filteredResult,
+                                                       criteria.ShowOpen,
+                                                       criteria.ShowClosed,
+                                                       criteria.LatLonField);
             }
             else if (criteria.ColorByTipoSigfi)
             {
@@ -295,7 +292,8 @@ namespace ManutMap
                                                             criteria.ColorByTipoServico ? criteria.ColorServicoPreventiva : criteria.ColorPreventiva,
                                                             criteria.ColorByTipoServico ? criteria.ColorServicoCorretiva : criteria.ColorCorretiva,
                                                             criteria.ColorServicoOutros,
-                                                            criteria.LatLonField);
+                                                            criteria.LatLonField,
+                                                            criteria.ColorByTipoServico);
 
             var fileName = $"mapa_{DateTime.Now:yyyyMMddHHmmss}.html";
             var link = await _spService.UploadHtmlAndShareAsync(fileName, html);

--- a/Services/MapService.cs
+++ b/Services/MapService.cs
@@ -86,5 +86,20 @@ namespace ManutMap.Services
             else
                 _view.ExecuteScriptAsync(script);
         }
+
+        public void AddMarkersByTipoServicoIcon(IEnumerable<JObject> data,
+                                               bool showOpen,
+                                               bool showClosed,
+                                               string latLonField = "LATLON")
+        {
+            var json = JsonConvert.SerializeObject(data);
+            var script =
+                $"addMarkersByTipoServicoIcon({json},{showOpen.ToString().ToLower()},{showClosed.ToString().ToLower()},'{latLonField}');";
+
+            if (!_ready)
+                _pendingScripts.Add(script);
+            else
+                _view.ExecuteScriptAsync(script);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add Leaflet function `addMarkersByTipoServicoIcon` for distinct icons
- expose `AddMarkersByTipoServicoIcon` in `MapService`
- call icon method when color by job type is enabled
- support optional `iconByTipo` parameter in `GetHtmlWithData`

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68667da4154083339ead0dee4b257bbf