### PR TITLE
Fix raw string closing line for map HTML

### DIFF
--- a/Helpers/MapHtmlHelper.cs
+++ b/Helpers/MapHtmlHelper.cs
@@ -268,8 +268,9 @@ namespace ManutMap.Helpers
         map.fitBounds(grp.getBounds().pad(0.2));
       }
     }
-  </script>
-</body></html>""";
+    </script>
+</body></html>
+        """;
 
         public static string GetHtmlWithData(IEnumerable<JObject> data,
                                              bool colorBySigfi,


### PR DESCRIPTION
## Summary
- fix closing delimiter for raw HTML string

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866827e488c8333b9d01b8bb0a20c2c