### PR TITLE
Switch color fields to dropdowns

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -247,10 +247,28 @@
                                     <StackPanel>
                                         <CheckBox x:Name="ChbOpen" Content="Exibir OS Abertas" IsChecked="True" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
                                         <TextBlock Text="Cor (Aberto):" Style="{StaticResource LabelTextBlock}" Margin="10,5,0,2"/>
-                                        <TextBox x:Name="TxtColorOpen" Width="100" Margin="10,0,0,10" Text="#FF0000"/>
+                                        <ComboBox x:Name="ColorOpenCombo" SelectionChanged="FiltersChanged" Width="120" Margin="10,0,0,10">
+                                            <ComboBoxItem Content="Vermelho" Tag="#FF0000" IsSelected="True"/>
+                                            <ComboBoxItem Content="Verde" Tag="#008000"/>
+                                            <ComboBoxItem Content="Azul" Tag="#0000FF"/>
+                                            <ComboBoxItem Content="Laranja" Tag="#FFA500"/>
+                                            <ComboBoxItem Content="Amarelo" Tag="#FFFF00"/>
+                                            <ComboBoxItem Content="Roxo" Tag="#800080"/>
+                                            <ComboBoxItem Content="Preto" Tag="#000000"/>
+                                            <ComboBoxItem Content="Cinza" Tag="#808080"/>
+                                        </ComboBox>
                                         <CheckBox x:Name="ChbClosed" Content="Exibir OS Concluídas" IsChecked="True" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
                                         <TextBlock Text="Cor (Concluído):" Style="{StaticResource LabelTextBlock}" Margin="10,5,0,2"/>
-                                        <TextBox x:Name="TxtColorClosed" Width="100" Margin="10,0,0,0" Text="#008000"/>
+                                        <ComboBox x:Name="ColorClosedCombo" SelectionChanged="FiltersChanged" Width="120" Margin="10,0,0,0">
+                                            <ComboBoxItem Content="Verde" Tag="#008000" IsSelected="True"/>
+                                            <ComboBoxItem Content="Vermelho" Tag="#FF0000"/>
+                                            <ComboBoxItem Content="Azul" Tag="#0000FF"/>
+                                            <ComboBoxItem Content="Laranja" Tag="#FFA500"/>
+                                            <ComboBoxItem Content="Amarelo" Tag="#FFFF00"/>
+                                            <ComboBoxItem Content="Roxo" Tag="#800080"/>
+                                            <ComboBoxItem Content="Preto" Tag="#000000"/>
+                                            <ComboBoxItem Content="Cinza" Tag="#808080"/>
+                                        </ComboBox>
                                     </StackPanel>
                                 </GroupBox>
 
@@ -258,10 +276,28 @@
                                     <StackPanel>
                                         <CheckBox x:Name="ChbColorBySigfi" Content="Ativar Coloração por Tipo SIGFI" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
                                         <TextBlock Text="Cor Preventiva:" Style="{StaticResource LabelTextBlock}" Margin="10,5,0,2"/>
-                                        <TextBox x:Name="TxtColorPrev" Width="100" Margin="10,0,0,5" Text="#0000FF"/>
+                                        <ComboBox x:Name="ColorPrevCombo" SelectionChanged="FiltersChanged" Width="120" Margin="10,0,0,5">
+                                            <ComboBoxItem Content="Azul" Tag="#0000FF" IsSelected="True"/>
+                                            <ComboBoxItem Content="Vermelho" Tag="#FF0000"/>
+                                            <ComboBoxItem Content="Verde" Tag="#008000"/>
+                                            <ComboBoxItem Content="Laranja" Tag="#FFA500"/>
+                                            <ComboBoxItem Content="Amarelo" Tag="#FFFF00"/>
+                                            <ComboBoxItem Content="Roxo" Tag="#800080"/>
+                                            <ComboBoxItem Content="Preto" Tag="#000000"/>
+                                            <ComboBoxItem Content="Cinza" Tag="#808080"/>
+                                        </ComboBox>
 
                                         <TextBlock Text="Cor Corretiva:" Style="{StaticResource LabelTextBlock}" Margin="10,5,0,2"/>
-                                        <TextBox x:Name="TxtColorCorr" Width="100" Margin="10,0,0,0" Text="#FFA500"/>
+                                        <ComboBox x:Name="ColorCorrCombo" SelectionChanged="FiltersChanged" Width="120" Margin="10,0,0,0">
+                                            <ComboBoxItem Content="Laranja" Tag="#FFA500" IsSelected="True"/>
+                                            <ComboBoxItem Content="Vermelho" Tag="#FF0000"/>
+                                            <ComboBoxItem Content="Verde" Tag="#008000"/>
+                                            <ComboBoxItem Content="Azul" Tag="#0000FF"/>
+                                            <ComboBoxItem Content="Amarelo" Tag="#FFFF00"/>
+                                            <ComboBoxItem Content="Roxo" Tag="#800080"/>
+                                            <ComboBoxItem Content="Preto" Tag="#000000"/>
+                                            <ComboBoxItem Content="Cinza" Tag="#808080"/>
+                                        </ComboBox>
                                     </StackPanel>
                                 </GroupBox>
 
@@ -269,13 +305,41 @@
                                     <StackPanel>
                                         <CheckBox x:Name="ChbColorByTipo" Content="Ativar Coloração por Serviço" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
                                         <TextBlock Text="Cor Preventiva:" Style="{StaticResource LabelTextBlock}" Margin="10,5,0,2"/>
-                                        <TextBox x:Name="TxtColorTipoPrev" Width="100" Margin="10,0,0,5" Text="#0000FF"/>
+                                        <ComboBox x:Name="ColorTipoPrevCombo" SelectionChanged="FiltersChanged" Width="120" Margin="10,0,0,5">
+                                            <ComboBoxItem Content="Azul" Tag="#0000FF" IsSelected="True"/>
+                                            <ComboBoxItem Content="Vermelho" Tag="#FF0000"/>
+                                            <ComboBoxItem Content="Verde" Tag="#008000"/>
+                                            <ComboBoxItem Content="Laranja" Tag="#FFA500"/>
+                                            <ComboBoxItem Content="Amarelo" Tag="#FFFF00"/>
+                                            <ComboBoxItem Content="Roxo" Tag="#800080"/>
+                                            <ComboBoxItem Content="Preto" Tag="#000000"/>
+                                            <ComboBoxItem Content="Cinza" Tag="#808080"/>
+                                        </ComboBox>
 
                                         <TextBlock Text="Cor Corretiva:" Style="{StaticResource LabelTextBlock}" Margin="10,5,0,2"/>
-                                        <TextBox x:Name="TxtColorTipoCorr" Width="100" Margin="10,0,0,5" Text="#FFA500"/>
+                                        <ComboBox x:Name="ColorTipoCorrCombo" SelectionChanged="FiltersChanged" Width="120" Margin="10,0,0,5">
+                                            <ComboBoxItem Content="Laranja" Tag="#FFA500" IsSelected="True"/>
+                                            <ComboBoxItem Content="Vermelho" Tag="#FF0000"/>
+                                            <ComboBoxItem Content="Verde" Tag="#008000"/>
+                                            <ComboBoxItem Content="Azul" Tag="#0000FF"/>
+                                            <ComboBoxItem Content="Amarelo" Tag="#FFFF00"/>
+                                            <ComboBoxItem Content="Roxo" Tag="#800080"/>
+                                            <ComboBoxItem Content="Preto" Tag="#000000"/>
+                                            <ComboBoxItem Content="Cinza" Tag="#808080"/>
+                                        </ComboBox>
 
                                         <TextBlock Text="Cor Serviços:" Style="{StaticResource LabelTextBlock}" Margin="10,5,0,2"/>
-                                        <TextBox x:Name="TxtColorTipoServ" Width="100" Margin="10,0,0,0" Text="#008080"/>
+                                        <ComboBox x:Name="ColorTipoServCombo" SelectionChanged="FiltersChanged" Width="120" Margin="10,0,0,0">
+                                            <ComboBoxItem Content="Teal" Tag="#008080" IsSelected="True"/>
+                                            <ComboBoxItem Content="Vermelho" Tag="#FF0000"/>
+                                            <ComboBoxItem Content="Verde" Tag="#008000"/>
+                                            <ComboBoxItem Content="Azul" Tag="#0000FF"/>
+                                            <ComboBoxItem Content="Laranja" Tag="#FFA500"/>
+                                            <ComboBoxItem Content="Amarelo" Tag="#FFFF00"/>
+                                            <ComboBoxItem Content="Roxo" Tag="#800080"/>
+                                            <ComboBoxItem Content="Preto" Tag="#000000"/>
+                                            <ComboBoxItem Content="Cinza" Tag="#808080"/>
+                                        </ComboBox>
                                     </StackPanel>
                                 </GroupBox>
 

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -72,17 +72,17 @@ namespace ManutMap
             ChbOpen.Unchecked += FiltersChanged;
             ChbClosed.Checked += FiltersChanged;
             ChbClosed.Unchecked += FiltersChanged;
-            TxtColorOpen.TextChanged += FiltersChanged;
-            TxtColorClosed.TextChanged += FiltersChanged;
+            ColorOpenCombo.SelectionChanged += FiltersChanged;
+            ColorClosedCombo.SelectionChanged += FiltersChanged;
             ChbColorBySigfi.Checked += FiltersChanged;
             ChbColorBySigfi.Unchecked += FiltersChanged;
-            TxtColorPrev.TextChanged += FiltersChanged;
-            TxtColorCorr.TextChanged += FiltersChanged;
+            ColorPrevCombo.SelectionChanged += FiltersChanged;
+            ColorCorrCombo.SelectionChanged += FiltersChanged;
             ChbColorByTipo.Checked += FiltersChanged;
             ChbColorByTipo.Unchecked += FiltersChanged;
-            TxtColorTipoPrev.TextChanged += FiltersChanged;
-            TxtColorTipoCorr.TextChanged += FiltersChanged;
-            TxtColorTipoServ.TextChanged += FiltersChanged;
+            ColorTipoPrevCombo.SelectionChanged += FiltersChanged;
+            ColorTipoCorrCombo.SelectionChanged += FiltersChanged;
+            ColorTipoServCombo.SelectionChanged += FiltersChanged;
         }
 
         private void LoadLocalAndPopulate()
@@ -178,15 +178,15 @@ namespace ManutMap
                 EndDate = EndDatePicker.SelectedDate,
                 ShowOpen = ChbOpen.IsChecked == true,
                 ShowClosed = ChbClosed.IsChecked == true,
-                ColorOpen = TxtColorOpen.Text.Trim(),
-                ColorClosed = TxtColorClosed.Text.Trim(),
+                ColorOpen = (ColorOpenCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#FF0000",
+                ColorClosed = (ColorClosedCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#008000",
                 ColorByTipoSigfi = ChbColorBySigfi.IsChecked == true,
-                ColorPreventiva = TxtColorPrev.Text.Trim(),
-                ColorCorretiva = TxtColorCorr.Text.Trim(),
+                ColorPreventiva = (ColorPrevCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#0000FF",
+                ColorCorretiva = (ColorCorrCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#FFA500",
                 ColorByTipoServico = ChbColorByTipo.IsChecked == true,
-                ColorServicoPreventiva = TxtColorTipoPrev.Text.Trim(),
-                ColorServicoCorretiva = TxtColorTipoCorr.Text.Trim(),
-                ColorServicoOutros = TxtColorTipoServ.Text.Trim(),
+                ColorServicoPreventiva = (ColorTipoPrevCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#0000FF",
+                ColorServicoCorretiva = (ColorTipoCorrCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#FFA500",
+                ColorServicoOutros = (ColorTipoServCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#008080",
                 LatLonField = (LatLonFieldCombo.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? "LATLON"
             };
         }


### PR DESCRIPTION
## Summary
- change manual color inputs to comboboxes with preset colors
- update event hookups and filter code accordingly

## Testing
- `dotnet build -clp:ErrorsOnly` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68668f5371c4833387b8f6050c4636a9