### PR TITLE
Update service color options and remove SIGFI toggle

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -272,38 +272,10 @@
                                     </StackPanel>
                                 </GroupBox>
 
-                                <GroupBox Header="Colorir por Tipo SIGFI">
-                                    <StackPanel>
-                                        <CheckBox x:Name="ChbColorBySigfi" Content="Ativar Coloração por Tipo SIGFI" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
-                                        <TextBlock Text="Cor Preventiva:" Style="{StaticResource LabelTextBlock}" Margin="10,5,0,2"/>
-                                        <ComboBox x:Name="ColorPrevCombo" SelectionChanged="FiltersChanged" Width="120" Margin="10,0,0,5">
-                                            <ComboBoxItem Content="Azul" Tag="#0000FF" IsSelected="True"/>
-                                            <ComboBoxItem Content="Vermelho" Tag="#FF0000"/>
-                                            <ComboBoxItem Content="Verde" Tag="#008000"/>
-                                            <ComboBoxItem Content="Laranja" Tag="#FFA500"/>
-                                            <ComboBoxItem Content="Amarelo" Tag="#FFFF00"/>
-                                            <ComboBoxItem Content="Roxo" Tag="#800080"/>
-                                            <ComboBoxItem Content="Preto" Tag="#000000"/>
-                                            <ComboBoxItem Content="Cinza" Tag="#808080"/>
-                                        </ComboBox>
-
-                                        <TextBlock Text="Cor Corretiva:" Style="{StaticResource LabelTextBlock}" Margin="10,5,0,2"/>
-                                        <ComboBox x:Name="ColorCorrCombo" SelectionChanged="FiltersChanged" Width="120" Margin="10,0,0,0">
-                                            <ComboBoxItem Content="Laranja" Tag="#FFA500" IsSelected="True"/>
-                                            <ComboBoxItem Content="Vermelho" Tag="#FF0000"/>
-                                            <ComboBoxItem Content="Verde" Tag="#008000"/>
-                                            <ComboBoxItem Content="Azul" Tag="#0000FF"/>
-                                            <ComboBoxItem Content="Amarelo" Tag="#FFFF00"/>
-                                            <ComboBoxItem Content="Roxo" Tag="#800080"/>
-                                            <ComboBoxItem Content="Preto" Tag="#000000"/>
-                                            <ComboBoxItem Content="Cinza" Tag="#808080"/>
-                                        </ComboBox>
-                                    </StackPanel>
-                                </GroupBox>
 
                                 <GroupBox Header="Colorir por Tipo de Serviço">
                                     <StackPanel>
-                                        <CheckBox x:Name="ChbColorByTipo" Content="Ativar Coloração por Serviço" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
+                                        <CheckBox x:Name="ChbColorPrev" Content="Colorir Preventiva" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
                                         <TextBlock Text="Cor Preventiva:" Style="{StaticResource LabelTextBlock}" Margin="10,5,0,2"/>
                                         <ComboBox x:Name="ColorTipoPrevCombo" SelectionChanged="FiltersChanged" Width="120" Margin="10,0,0,5">
                                             <ComboBoxItem Content="Azul" Tag="#0000FF" IsSelected="True"/>
@@ -315,7 +287,7 @@
                                             <ComboBoxItem Content="Preto" Tag="#000000"/>
                                             <ComboBoxItem Content="Cinza" Tag="#808080"/>
                                         </ComboBox>
-
+                                        <CheckBox x:Name="ChbColorCorr" Content="Colorir Corretiva" Margin="0,5,0,0" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
                                         <TextBlock Text="Cor Corretiva:" Style="{StaticResource LabelTextBlock}" Margin="10,5,0,2"/>
                                         <ComboBox x:Name="ColorTipoCorrCombo" SelectionChanged="FiltersChanged" Width="120" Margin="10,0,0,5">
                                             <ComboBoxItem Content="Laranja" Tag="#FFA500" IsSelected="True"/>
@@ -327,7 +299,7 @@
                                             <ComboBoxItem Content="Preto" Tag="#000000"/>
                                             <ComboBoxItem Content="Cinza" Tag="#808080"/>
                                         </ComboBox>
-
+                                        <CheckBox x:Name="ChbColorServ" Content="Colorir Serviços" Margin="0,5,0,0" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
                                         <TextBlock Text="Cor Serviços:" Style="{StaticResource LabelTextBlock}" Margin="10,5,0,2"/>
                                         <ComboBox x:Name="ColorTipoServCombo" SelectionChanged="FiltersChanged" Width="120" Margin="10,0,0,0">
                                             <ComboBoxItem Content="Teal" Tag="#008080" IsSelected="True"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -74,12 +74,12 @@ namespace ManutMap
             ChbClosed.Unchecked += FiltersChanged;
             ColorOpenCombo.SelectionChanged += FiltersChanged;
             ColorClosedCombo.SelectionChanged += FiltersChanged;
-            ChbColorBySigfi.Checked += FiltersChanged;
-            ChbColorBySigfi.Unchecked += FiltersChanged;
-            ColorPrevCombo.SelectionChanged += FiltersChanged;
-            ColorCorrCombo.SelectionChanged += FiltersChanged;
-            ChbColorByTipo.Checked += FiltersChanged;
-            ChbColorByTipo.Unchecked += FiltersChanged;
+            ChbColorPrev.Checked += FiltersChanged;
+            ChbColorPrev.Unchecked += FiltersChanged;
+            ChbColorCorr.Checked += FiltersChanged;
+            ChbColorCorr.Unchecked += FiltersChanged;
+            ChbColorServ.Checked += FiltersChanged;
+            ChbColorServ.Unchecked += FiltersChanged;
             ColorTipoPrevCombo.SelectionChanged += FiltersChanged;
             ColorTipoCorrCombo.SelectionChanged += FiltersChanged;
             ColorTipoServCombo.SelectionChanged += FiltersChanged;
@@ -180,10 +180,9 @@ namespace ManutMap
                 ShowClosed = ChbClosed.IsChecked == true,
                 ColorOpen = (ColorOpenCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#FF0000",
                 ColorClosed = (ColorClosedCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#008000",
-                ColorByTipoSigfi = ChbColorBySigfi.IsChecked == true,
-                ColorPreventiva = (ColorPrevCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#0000FF",
-                ColorCorretiva = (ColorCorrCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#FFA500",
-                ColorByTipoServico = ChbColorByTipo.IsChecked == true,
+                ColorPrevOn = ChbColorPrev.IsChecked == true,
+                ColorCorrOn = ChbColorCorr.IsChecked == true,
+                ColorServOn = ChbColorServ.IsChecked == true,
                 ColorServicoPreventiva = (ColorTipoPrevCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#0000FF",
                 ColorServicoCorretiva = (ColorTipoCorrCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#FFA500",
                 ColorServicoOutros = (ColorTipoServCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#008080",
@@ -213,21 +212,18 @@ namespace ManutMap
 
             var filteredResult = _filterSvc.Apply(_manutList, criteria);
 
-            if (criteria.ColorByTipoServico)
-            {
-                _mapService.AddMarkersByTipoServicoIcon(filteredResult,
-                                                       criteria.ShowOpen,
-                                                       criteria.ShowClosed,
-                                                       criteria.LatLonField);
-            }
-            else if (criteria.ColorByTipoSigfi)
-            {
-                _mapService.AddMarkersByTipoSigfi(filteredResult, criteria.ShowOpen, criteria.ShowClosed, criteria.ColorPreventiva, criteria.ColorCorretiva, criteria.LatLonField);
-            }
-            else
-            {
-                _mapService.AddMarkers(filteredResult, criteria.ShowOpen, criteria.ShowClosed, criteria.ColorOpen, criteria.ColorClosed, criteria.LatLonField);
-            }
+            _mapService.AddMarkersSelective(filteredResult,
+                                            criteria.ShowOpen,
+                                            criteria.ShowClosed,
+                                            criteria.ColorOpen,
+                                            criteria.ColorClosed,
+                                            criteria.ColorServicoPreventiva,
+                                            criteria.ColorServicoCorretiva,
+                                            criteria.ColorServicoOutros,
+                                            criteria.ColorPrevOn,
+                                            criteria.ColorCorrOn,
+                                            criteria.ColorServOn,
+                                            criteria.LatLonField);
 
             AtualizarPainelEstatisticas(filteredResult);
         }
@@ -283,17 +279,17 @@ namespace ManutMap
                 _fileService.SaveCsv(filtered, dialog.FileName, criteria.LatLonField);
             }
             var html = Helpers.MapHtmlHelper.GetHtmlWithData(filtered,
-                                                            criteria.ColorByTipoSigfi,
-                                                            criteria.ColorByTipoServico,
                                                             criteria.ShowOpen,
                                                             criteria.ShowClosed,
                                                             criteria.ColorOpen,
                                                             criteria.ColorClosed,
-                                                            criteria.ColorByTipoServico ? criteria.ColorServicoPreventiva : criteria.ColorPreventiva,
-                                                            criteria.ColorByTipoServico ? criteria.ColorServicoCorretiva : criteria.ColorCorretiva,
+                                                            criteria.ColorServicoPreventiva,
+                                                            criteria.ColorServicoCorretiva,
                                                             criteria.ColorServicoOutros,
-                                                            criteria.LatLonField,
-                                                            criteria.ColorByTipoServico);
+                                                            criteria.ColorPrevOn,
+                                                            criteria.ColorCorrOn,
+                                                            criteria.ColorServOn,
+                                                            criteria.LatLonField);
 
             var fileName = $"mapa_{DateTime.Now:yyyyMMddHHmmss}.html";
             var link = await _spService.UploadHtmlAndShareAsync(fileName, html);

--- a/Models/FilterCriteria.cs
+++ b/Models/FilterCriteria.cs
@@ -20,13 +20,10 @@ namespace ManutMap.Models
         public string ColorOpen { get; set; } = "#FF0000";
         public string ColorClosed { get; set; } = "#008000";
 
-        // Se true, usa cores baseadas no Tipo SIGFI
-        public bool ColorByTipoSigfi { get; set; }
-        public string ColorPreventiva { get; set; } = "#0000FF";
-        public string ColorCorretiva { get; set; } = "#FFA500";
-
-        // Cores por tipo de serviço (Preventiva/Corretiva/Serviços)
-        public bool ColorByTipoServico { get; set; }
+        // Configurações de cor por tipo de serviço
+        public bool ColorPrevOn { get; set; }
+        public bool ColorCorrOn { get; set; }
+        public bool ColorServOn { get; set; }
         public string ColorServicoPreventiva { get; set; } = "#0000FF";
         public string ColorServicoCorretiva { get; set; } = "#FFA500";
         public string ColorServicoOutros { get; set; } = "#008080";

--- a/Services/MapService.cs
+++ b/Services/MapService.cs
@@ -50,6 +50,31 @@ namespace ManutMap.Services
                 _view.ExecuteScriptAsync(script);
         }
 
+        public void AddMarkersSelective(IEnumerable<JObject> data,
+                                         bool showOpen,
+                                         bool showClosed,
+                                         string colorOpen,
+                                         string colorClosed,
+                                         string colorPrev,
+                                         string colorCorr,
+                                         string colorServ,
+                                         bool colorPrevOn,
+                                         bool colorCorrOn,
+                                         bool colorServOn,
+                                         string latLonField = "LATLON")
+        {
+            var json = JsonConvert.SerializeObject(data);
+            var script =
+                $"addMarkersSelective({json},{showOpen.ToString().ToLower()},{showClosed.ToString().ToLower()}," +
+                $"'{colorOpen}','{colorClosed}','{colorPrev}','{colorCorr}','{colorServ}'," +
+                $"{colorPrevOn.ToString().ToLower()},{colorCorrOn.ToString().ToLower()},{colorServOn.ToString().ToLower()},'{latLonField}');";
+
+            if (!_ready)
+                _pendingScripts.Add(script);
+            else
+                _view.ExecuteScriptAsync(script);
+        }
+
         public void AddMarkersByTipoSigfi(IEnumerable<JObject> data,
                                            bool showOpen,
                                            bool showClosed,


### PR DESCRIPTION
## Summary
- remove outdated "Colorir por Tipo SIGFI" section
- allow colouring each service type individually with new checkboxes
- update filtering logic and HTML helpers for per‑service colouring

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686694df09a883339a9d295ce8d8807c