### PR TITLE
Add clear filters button

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -198,9 +198,11 @@
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
                     <Button x:Name="DownloadButton" Grid.Column="0" Content="Baixar JSON" Style="{StaticResource PrimaryButton}" Click="DownloadButton_Click" Margin="0,0,5,0"/>
-                    <Button x:Name="ShareButton" Grid.Column="1" Content="Compartilhar" Style="{StaticResource PrimaryButton}" Click="ShareButton_Click" Margin="5,0,0,0"/>
+                    <Button x:Name="ShareButton" Grid.Column="1" Content="Compartilhar" Style="{StaticResource PrimaryButton}" Click="ShareButton_Click" Margin="5,0,5,0"/>
+                    <Button x:Name="ClearFiltersButton" Grid.Column="2" Content="Limpar Filtros" Style="{StaticResource PrimaryButton}" Click="ClearFiltersButton_Click"/>
                 </Grid>
 
                 <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="{StaticResource PanelPadding}">

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -318,5 +318,38 @@ namespace ManutMap
 
             _sidebarVisible = !_sidebarVisible;
         }
+
+        private void ClearFiltersButton_Click(object sender, RoutedEventArgs e)
+        {
+            SigfiFilterCombo.SelectedIndex = 0;
+            TipoFilterCombo.SelectedIndex = 0;
+            NumOsFilterBox.Text = string.Empty;
+            IdSigfiFilterBox.Text = string.Empty;
+
+            RegionalFilterCombo.SelectedIndex = 0;
+            PopulateComboBox(RotaFilterCombo, "ROTA");
+            RotaFilterCombo.SelectedIndex = 0;
+
+            StartDatePicker.SelectedDate = null;
+            EndDatePicker.SelectedDate = null;
+
+            ChbOpen.IsChecked = true;
+            ChbClosed.IsChecked = true;
+
+            ColorOpenCombo.SelectedIndex = 0;
+            ColorClosedCombo.SelectedIndex = 0;
+
+            ChbColorPrev.IsChecked = false;
+            ChbColorCorr.IsChecked = false;
+            ChbColorServ.IsChecked = false;
+
+            ColorTipoPrevCombo.SelectedIndex = 0;
+            ColorTipoCorrCombo.SelectedIndex = 0;
+            ColorTipoServCombo.SelectedIndex = 0;
+
+            LatLonFieldCombo.SelectedIndex = 0;
+
+            ApplyFilters();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add 'Limpar Filtros' button next to download/share buttons
- implement `ClearFiltersButton_Click` to reset every filter control to default values

## Testing
- `dotnet build -v minimal` *(fails: command not found)*
- `msbuild` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669b855ed483339626f77806c27247