### PR TITLE
Add datalog search feature

### DIFF
--- a/DatalogWindow.xaml
+++ b/DatalogWindow.xaml
@@ -1,0 +1,50 @@
+<Window x:Class="ManutMap.DatalogWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:sys="clr-namespace:System;assembly=mscorlib"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Buscar Datalog" Height="450" Width="800">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Orientation="Horizontal" Spacing="10">
+            <TextBlock Text="Início:" VerticalAlignment="Center"/>
+            <DatePicker x:Name="DpInicio" SelectedDate="{x:Static sys:DateTime.Today}"/>
+            <TextBlock Text="Fim:" VerticalAlignment="Center" Margin="20,0,0,0"/>
+            <DatePicker x:Name="DpFim" SelectedDate="{x:Static sys:DateTime.Today}"/>
+        </StackPanel>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="10" Margin="0,10,0,10">
+            <ComboBox x:Name="CmbFiltro" Width="120">
+                <ComboBoxItem Content="OS"/>
+                <ComboBoxItem Content="IDSIGFI"/>
+                <ComboBoxItem Content="Rota"/>
+                <ComboBoxItem Content="Instalação"/>
+            </ComboBox>
+            <TextBox x:Name="TxtBusca" Width="200"/>
+            <ComboBox x:Name="CmbRegional" Width="100" Margin="10,0,0,0">
+                <ComboBoxItem Content="Todas"/>
+                <ComboBoxItem Content="AC"/>
+                <ComboBoxItem Content="MT"/>
+            </ComboBox>
+            <Button x:Name="BtnBuscar" Content="Buscar" Click="BtnBuscar_Click"/>
+        </StackPanel>
+
+        <DataGrid Grid.Row="2" x:Name="GridOs" AutoGenerateColumns="False" Margin="0,0,0,10">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="OS" Binding="{Binding NumOS}" Width="*"/>
+                <DataGridTextColumn Header="IDSIGFI" Binding="{Binding IdSigfi}" Width="*"/>
+                <DataGridTextColumn Header="Rota" Binding="{Binding Rota}" Width="*"/>
+                <DataGridTextColumn Header="Data" Binding="{Binding Data}" Width="*"/>
+                <DataGridTextColumn Header="Status" Binding="{Binding Status}" Width="*"/>
+                <DataGridHyperlinkColumn Header="Pasta" Binding="{Binding FolderUrl}" Width="*"/>
+            </DataGrid.Columns>
+        </DataGrid>
+
+        <TextBlock Grid.Row="3" x:Name="TxtResumo"/>
+    </Grid>
+</Window>

--- a/DatalogWindow.xaml.cs
+++ b/DatalogWindow.xaml.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Linq;
+using System.Windows;
+using ManutMap.Models;
+using ManutMap.Services;
+using ManutMap.Helpers;
+
+namespace ManutMap
+{
+    public partial class DatalogWindow : Window
+    {
+        private readonly DatalogService _service = new();
+        public RelayCommand<string> CmdAbrir { get; }
+
+        public DatalogWindow()
+        {
+            InitializeComponent();
+            CmdAbrir = new RelayCommand<string>(u =>
+            {
+                if (!string.IsNullOrWhiteSpace(u))
+                    System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(u)
+                    {
+                        UseShellExecute = true
+                    });
+            });
+            DataContext = this;
+            CmbFiltro.SelectedIndex = 0;
+            CmbRegional.SelectedIndex = 0;
+        }
+
+        private async void BtnBuscar_Click(object sender, RoutedEventArgs e)
+        {
+            BtnBuscar.IsEnabled = false;
+            GridOs.ItemsSource = null;
+            TxtResumo.Text = "Consultando…";
+
+            DateTime ini = DpInicio.SelectedDate ?? DateTime.Today;
+            DateTime fim = (DpFim.SelectedDate ?? DateTime.Today).AddDays(1).AddTicks(-1);
+            string? termo = string.IsNullOrWhiteSpace(TxtBusca.Text) ? null : TxtBusca.Text.Trim();
+            int tipoFiltro = CmbFiltro.SelectedIndex;
+            string? regionalSel = CmbRegional.SelectedIndex switch
+            {
+                1 => "AC",
+                2 => "MT",
+                _ => null
+            };
+
+            try
+            {
+                var lista = await _service.BuscarAsync(ini, fim, termo, tipoFiltro, regionalSel);
+                TxtResumo.Text =
+                    $"Total: {lista.Count} | Com datalog: {lista.Count(i => i.TemDatalog)} | Sem datalog: {lista.Count(i => !i.TemDatalog)}";
+                GridOs.ItemsSource = lista;
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(ex.Message, "Erro", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
+            finally { BtnBuscar.IsEnabled = true; }
+        }
+    }
+}

--- a/Helpers/RelayCommand.cs
+++ b/Helpers/RelayCommand.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Windows.Input;
+
+namespace ManutMap.Helpers
+{
+    public class RelayCommand<T> : ICommand
+    {
+        private readonly Action<T?> _act;
+        public RelayCommand(Action<T?> act) => _act = act;
+        public bool CanExecute(object? _) => true;
+        public void Execute(object? parameter) => _act((T?)parameter);
+        public event EventHandler? CanExecuteChanged { add { } remove { } }
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -199,10 +199,12 @@
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
                     <Button x:Name="DownloadButton" Grid.Column="0" Content="Baixar JSON" Style="{StaticResource PrimaryButton}" Click="DownloadButton_Click" Margin="0,0,5,0"/>
                     <Button x:Name="ShareButton" Grid.Column="1" Content="Compartilhar" Style="{StaticResource PrimaryButton}" Click="ShareButton_Click" Margin="5,0,5,0"/>
-                    <Button x:Name="ClearFiltersButton" Grid.Column="2" Content="Limpar Filtros" Style="{StaticResource PrimaryButton}" Click="ClearFiltersButton_Click"/>
+                    <Button x:Name="ClearFiltersButton" Grid.Column="2" Content="Limpar Filtros" Style="{StaticResource PrimaryButton}" Click="ClearFiltersButton_Click" Margin="5,0,5,0"/>
+                    <Button x:Name="DatalogButton" Grid.Column="3" Content="Buscar Datalog" Style="{StaticResource PrimaryButton}" Click="DatalogButton_Click"/>
                 </Grid>
 
                 <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="{StaticResource PanelPadding}">

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -351,5 +351,12 @@ namespace ManutMap
 
             ApplyFilters();
         }
+
+        private void DatalogButton_Click(object sender, RoutedEventArgs e)
+        {
+            var win = new DatalogWindow();
+            win.Owner = this;
+            win.Show();
+        }
     }
 }

--- a/Models/OsInfo.cs
+++ b/Models/OsInfo.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace ManutMap.Models
+{
+    public class OsInfo
+    {
+        public required string NumOS { get; init; }
+        public required string IdSigfi { get; init; }
+        public required string Rota { get; init; }
+        public DateTime? Data { get; init; }
+        public bool TemDatalog { get; set; }
+        public string? FolderUrl { get; set; }
+        public string Status => TemDatalog ? "Com datalog" : "Sem datalog";
+    }
+}

--- a/Services/DatalogService.cs
+++ b/Services/DatalogService.cs
@@ -1,0 +1,263 @@
+using Azure.Identity;
+using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using Microsoft.Kiota.Abstractions;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ManutMap.Models;
+
+namespace ManutMap.Services
+{
+    public class DatalogService
+    {
+        private const string TenantId = "3b08e64e-b3be-402b-bb26-1fa4f91cf61f";
+        private const string ClientId = "3cffac6a-f9d9-42d1-9065-4054fcd40163";
+        private const string ClientSecret = "JFd8Q~hHgTYYo0P0EjAM8mpe3xm3.5vTfCHRFc.T";
+
+        private const string Domain = "oneengenharia.sharepoint.com";
+        private const string SitePath = "OneEngenharia";
+        private const string DriveDatalog = "DatalogGERAL";
+        private const string DriveJson = "ArquivosJSON";
+
+        private static readonly string[] JsonSuffixes =
+        {
+            "__Manutencao_AC2025.json",
+            "__Manutencao_MT.json"
+        };
+
+        private readonly GraphServiceClient _graph;
+
+        public DatalogService()
+        {
+            _graph = new GraphServiceClient(
+                new ClientSecretCredential(TenantId, ClientId, ClientSecret),
+                new[] { "https://graph.microsoft.com/.default" });
+        }
+
+        public async Task<List<OsInfo>> BuscarAsync(DateTime ini,
+                                                    DateTime fim,
+                                                    string? termo,
+                                                    int tipoFiltro,
+                                                    string? regional)
+        {
+            var site = await _graph.Sites[$"{Domain}:/sites/{SitePath}"].GetAsync();
+
+            string jsonDriveId = await GetDriveId(site.Id, DriveJson);
+            var jsonItens = await GetLatestJsonsAsync(jsonDriveId);
+
+            var mapa = new Dictionary<string, OsInfo>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var itm in jsonItens)
+            {
+                var infos = await GetOsInfosAsync(jsonDriveId, itm.Id!, ini, fim,
+                                                termo, tipoFiltro, termo != null, regional);
+                foreach (var inf in infos)
+                    mapa[inf.NumOS] = inf;
+            }
+
+            string dataDriveId = await GetDriveId(site.Id, DriveDatalog);
+            var pastas = await GetPastasPeriodoAsync(dataDriveId, ini, fim,
+                                                     termo != null, termo,
+                                                     tipoFiltro, regional);
+
+            foreach (var inf in mapa.Values)
+                if (pastas.TryGetValue(inf.NumOS, out var url))
+                {
+                    inf.TemDatalog = true;
+                    inf.FolderUrl = url;
+                }
+
+            return mapa.Values.OrderBy(i => i.NumOS).ToList();
+        }
+
+        private async Task<string> GetDriveId(string siteId, string driveName)
+        {
+            var drives = await _graph.Sites[siteId].Drives.GetAsync();
+            return drives.Value.First(d => d.Name == driveName).Id!;
+        }
+
+        private async Task<List<DriveItem>> GetAllRootFoldersAsync(string driveId)
+        {
+            var lista = new List<DriveItem>();
+
+            var page = await _graph.Drives[driveId].Items["root"].Children.GetAsync();
+            lista.AddRange(page.Value.Where(i => i.Folder != null));
+
+            while (page.OdataNextLink is string next)
+            {
+                var req = new RequestInformation
+                {
+                    HttpMethod = Method.GET,
+                    UrlTemplate = next,
+                    PathParameters = new Dictionary<string, object>()
+                };
+
+                page = await _graph.RequestAdapter.SendAsync(
+                           req, DriveItemCollectionResponse.CreateFromDiscriminatorValue);
+
+                lista.AddRange(page!.Value.Where(i => i.Folder != null));
+            }
+            return lista;
+        }
+
+        private async Task<List<DriveItem>> GetLatestJsonsAsync(string driveId)
+        {
+            var pg = await _graph.Drives[driveId].Items["root"].Children.GetAsync();
+            var list = new List<DriveItem>();
+
+            foreach (var suf in JsonSuffixes)
+            {
+                var arquivos = pg.Value
+                    .Where(f => f.File != null &&
+                                f.Name.EndsWith(suf, StringComparison.OrdinalIgnoreCase))
+                    .OrderByDescending(f => f.LastModifiedDateTime)
+                    .ToList();
+
+                if (arquivos.Count > 0)
+                    list.Add(arquivos.First());
+            }
+
+            if (list.Count == 0)
+                throw new InvalidOperationException("Nenhum JSON de manutenção encontrado.");
+
+            return list;
+        }
+
+        private async Task<List<OsInfo>> GetOsInfosAsync(string driveId,
+                                                         string itemId,
+                                                         DateTime ini,
+                                                         DateTime fim,
+                                                         string? termo,
+                                                         int tipoFiltro,
+                                                         bool buscaUnica,
+                                                         string? regionalSel)
+        {
+            using var st = await _graph.Drives[driveId].Items[itemId].Content.GetAsync();
+            using var sr = new StreamReader(st, Encoding.UTF8);
+            var root = JObject.Parse(await sr.ReadToEndAsync());
+
+            if (root["manutencoes"] is not JArray arr)
+                throw new InvalidOperationException("JSON sem 'manutencoes'.");
+
+            var list = new List<OsInfo>();
+
+            foreach (var t in arr)
+            {
+                string num = t.Value<string>("NUMOS")?.Trim() ?? "";
+                string sigfi = t.Value<string>("IDSIGFI")?.Trim() ?? "";
+                string rota = t.Value<string>("ROTA")?.Trim() ?? "-";
+                if (num == "") continue;
+
+                if (regionalSel != null &&
+                    !num.StartsWith(regionalSel, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                DateTime? dataJson = null;
+
+                if (!buscaUnica)
+                {
+                    var dtStr = t.Value<string>("DATACONCLUSAO");
+                    if (string.IsNullOrWhiteSpace(dtStr)) continue;
+
+                    var dt = DateTime.Parse(dtStr, CultureInfo.InvariantCulture,
+                                            DateTimeStyles.AssumeUniversal);
+                    if (dt < ini || dt > fim) continue;
+                    dataJson = dt;
+                }
+                else
+                {
+                    bool ok = tipoFiltro switch
+                    {
+                        0 => num.Equals(termo!, StringComparison.OrdinalIgnoreCase),
+                        1 => sigfi.Equals(termo!, StringComparison.OrdinalIgnoreCase),
+                        2 => rota.Equals(termo!, StringComparison.OrdinalIgnoreCase),
+                        _ => false
+                    };
+                    if (!ok) continue;
+
+                    if (DateTime.TryParse(t.Value<string>("DATACONCLUSAO"),
+                                          CultureInfo.InvariantCulture,
+                                          DateTimeStyles.AssumeUniversal, out var dtTmp))
+                        dataJson = dtTmp;
+                }
+
+                list.Add(new OsInfo
+                {
+                    NumOS = num,
+                    IdSigfi = sigfi,
+                    Rota = rota,
+                    Data = dataJson
+                });
+            }
+            return list;
+        }
+
+        private async Task<Dictionary<string, string>> GetPastasPeriodoAsync(string driveId,
+                                                                             DateTime ini,
+                                                                             DateTime fim,
+                                                                             bool buscaUnica,
+                                                                             string? termo,
+                                                                             int tipoFiltro,
+                                                                             string? regionalSel)
+        {
+            var all = await GetAllRootFoldersAsync(driveId);
+            var q = all.AsEnumerable();
+
+            if (!buscaUnica)
+                q = q.Where(i => i.CreatedDateTime >= ini && i.CreatedDateTime <= fim);
+
+            if (regionalSel != null)
+                q = q.Where(i => i.Name!.StartsWith(regionalSel, StringComparison.OrdinalIgnoreCase));
+
+            if (buscaUnica && tipoFiltro == 2 && termo != null)
+                q = q.Where(i => i.Name!.Contains(termo, StringComparison.OrdinalIgnoreCase));
+
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var it in q)
+            {
+                string name = it.Name!.Trim();
+                string url = it.WebUrl ??
+                              $"https://{Domain}/sites/{SitePath}/{DriveDatalog}/{name}";
+
+                dict[name] = url;
+
+                int idx = name.IndexOf('_');
+                if (idx > 0)
+                {
+                    string prefix = name[..idx];
+                    dict.TryAdd(prefix, url);
+
+                    if (idx == name.Length - 1)
+                        dict.TryAdd(prefix.TrimEnd('_'), url);
+                }
+            }
+            return dict;
+        }
+
+        public async Task<List<(string Url, DateTime Date)>> GetPastasInstalacaoAsync(string driveId,
+                                                                                      string? idSigfi)
+        {
+            var all = await GetAllRootFoldersAsync(driveId);
+
+            var q = all.Where(i => i.Name!.EndsWith("_instalacao",
+                                       StringComparison.OrdinalIgnoreCase));
+
+            if (!string.IsNullOrWhiteSpace(idSigfi))
+                q = q.Where(i => i.Name!.StartsWith(idSigfi, StringComparison.OrdinalIgnoreCase));
+
+            return q.Select(i => (
+                        i.WebUrl ??
+                        $"https://{Domain}/sites/{SitePath}/{DriveDatalog}/{i.Name!.Trim()}",
+                        (i.LastModifiedDateTime ?? i.CreatedDateTime ?? DateTimeOffset.MinValue)
+                            .UtcDateTime))
+                    .ToList();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `DatalogService` with routines for querying datalog files on SharePoint
- add `OsInfo` model and `RelayCommand` helper
- create `DatalogWindow` to search and list datalog folders
- link new window from main UI with a button

## Testing
- `dotnet build -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669dda0e288333a70b47c7412335a1