### PR TITLE
Fix datalog info mismatch on map

### DIFF
--- a/DatalogWindow.xaml.cs
+++ b/DatalogWindow.xaml.cs
@@ -48,6 +48,8 @@ namespace ManutMap
             try
             {
                 var lista = await _service.BuscarAsync(ini, fim, termo, tipoFiltro, regionalSel);
+                if (Owner is MainWindow mainWin)
+                    mainWin.UpdateDatalogMap(lista);
                 TxtResumo.Text =
                     $"Total: {lista.Count} | Com datalog: {lista.Count(i => i.TemDatalog)} | Sem datalog: {lista.Count(i => !i.TemDatalog)}";
                 GridOs.ItemsSource = lista;


### PR DESCRIPTION
## Summary
- update DatalogService with method to list all datalog folders
- load datalog folder map when refreshing data and annotate json items
- update datalog map when searching from DatalogWindow

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866a7d078a48333b11083d13324cfe0