### PR TITLE
Fix JSON merge to include all maintenance files

### DIFF
--- a/Services/DatalogService.cs
+++ b/Services/DatalogService.cs
@@ -28,6 +28,8 @@ namespace ManutMap.Services
         private static readonly string[] JsonSuffixes =
         {
             "__Manutencao_AC2025.json",
+            "__Manutencao_AC2024.json",
+            "__Manutencao_AC2023.json",
             "__Manutencao_MT.json"
         };
 


### PR DESCRIPTION
## Summary
- merge all maintenance files from SharePoint instead of the latest per prefix
- include all known JSON suffixes in datalog service

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet build ManutMap.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866bbbd4fe88333a0fddb75dc7f1626