### PR TITLE
Add filter for datalog-only OS

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -226,7 +226,8 @@
                             <Expander Header="Visualização e Camadas" IsExpanded="True">
                                 <StackPanel>
                                     <CheckBox x:Name="ChbOpen" Content="Exibir OS Abertas" IsChecked="True" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
-                                    <CheckBox x:Name="ChbClosed" Content="Exibir OS Concluídas" IsChecked="True" Checked="FiltersChanged" Unchecked="FiltersChanged" Margin="0,5,0,15"/>
+                                    <CheckBox x:Name="ChbClosed" Content="Exibir OS Concluídas" IsChecked="True" Checked="FiltersChanged" Unchecked="FiltersChanged" Margin="0,5,0,0"/>
+                                    <CheckBox x:Name="ChbOnlyDatalog" Content="Apenas OS com Datalog" Checked="FiltersChanged" Unchecked="FiltersChanged" Margin="0,5,0,15"/>
 
                                     <CheckBox x:Name="ChbColorPrev" Content="Colorir por Preventiva" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
                                     <CheckBox x:Name="ChbColorCorr" Content="Colorir por Corretiva" Margin="0,5,0,0" Checked="FiltersChanged" Unchecked="FiltersChanged"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -74,6 +74,8 @@ namespace ManutMap
             ChbOpen.Unchecked += FiltersChanged;
             ChbClosed.Checked += FiltersChanged;
             ChbClosed.Unchecked += FiltersChanged;
+            ChbOnlyDatalog.Checked += FiltersChanged;
+            ChbOnlyDatalog.Unchecked += FiltersChanged;
             ColorOpenCombo.SelectionChanged += FiltersChanged;
             ColorClosedCombo.SelectionChanged += FiltersChanged;
             ChbColorPrev.Checked += FiltersChanged;
@@ -191,7 +193,8 @@ namespace ManutMap
                 ColorServicoPreventiva = (ColorTipoPrevCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#0000FF",
                 ColorServicoCorretiva = (ColorTipoCorrCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#FFA500",
                 ColorServicoOutros = (ColorTipoServCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#008080",
-                LatLonField = (LatLonFieldCombo.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? "LATLON"
+                LatLonField = (LatLonFieldCombo.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? "LATLON",
+                OnlyDatalog = ChbOnlyDatalog.IsChecked == true
             };
         }
 
@@ -390,6 +393,7 @@ namespace ManutMap
 
             ChbOpen.IsChecked = true;
             ChbClosed.IsChecked = true;
+            ChbOnlyDatalog.IsChecked = false;
 
             ColorOpenCombo.SelectedIndex = 0;
             ColorClosedCombo.SelectedIndex = 0;

--- a/Models/FilterCriteria.cs
+++ b/Models/FilterCriteria.cs
@@ -31,6 +31,9 @@ namespace ManutMap.Models
         // NOVO: qual campo de coordenada usar
         // "LATLON" ou "LATLONCON"
         public string LatLonField { get; set; } = "LATLON";
+
+        // Exibir apenas itens com datalog disponível
+        public bool OnlyDatalog { get; set; }
     }
 }
 

--- a/Services/FilterService.cs
+++ b/Services/FilterService.cs
@@ -57,6 +57,12 @@ namespace ManutMap.Services
                             return false;
                     }
 
+                    if (c.OnlyDatalog)
+                    {
+                        var tem = item["TEMDATALOG"]?.ToObject<bool>() ?? false;
+                        if (!tem) return false;
+                    }
+
                     var dtRec = item["DTAHORARECLAMACAO"]?.ToString();
                     var dtCon = item["DTCONCLUSAO"]?.ToString();
                     bool isOpen = !string.IsNullOrWhiteSpace(dtRec) && string.IsNullOrWhiteSpace(dtCon);


### PR DESCRIPTION
## Summary
- add `OnlyDatalog` property in filter criteria
- filter out OS without datalogs
- expose checkbox `Apenas OS com Datalog` in the UI
- hook new filter into logic and reset on clearing filters

## Testing
- `dotnet build -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866c3e336b4833381e14ffb3c65976b