### PR TITLE
Fix duplicate markers when filtering by OS

### DIFF
--- a/Services/FilterService.cs
+++ b/Services/FilterService.cs
@@ -18,7 +18,7 @@ namespace ManutMap.Services
 
         public List<JObject> Apply(JArray source, FilterCriteria c)
         {
-            return source.OfType<JObject>()
+            var filtered = source.OfType<JObject>()
                 .Where(item =>
                 {
                     if (c.Sigfi != "Todos")
@@ -85,6 +85,12 @@ namespace ManutMap.Services
 
                     return true;
                 })
+                .ToList();
+
+            return filtered
+                .GroupBy(o => (o["NUMOS"]?.ToString() ?? string.Empty).Trim(),
+                         StringComparer.OrdinalIgnoreCase)
+                .Select(g => g.First())
                 .ToList();
         }
     }


### PR DESCRIPTION
## Summary
- deduplicate OS entries in `FilterService.Apply` so each OS appears once

## Testing
- `dotnet build ManutMap.sln -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6866f2f90cb08333bce2748e3f8d8814