### PR TITLE
Fix SharePoint JSON merge

### DIFF
--- a/Services/DatalogService.cs
+++ b/Services/DatalogService.cs
@@ -25,13 +25,6 @@ namespace ManutMap.Services
         private const string DriveDatalog = "DatalogGERAL";
         private const string DriveJson = "ArquivosJSON";
 
-        private static readonly string[] JsonSuffixes =
-        {
-            "__Manutencao_AC2025.json",
-            "__Manutencao_AC2024.json",
-            "__Manutencao_AC2023.json",
-            "__Manutencao_MT.json"
-        };
 
         private readonly GraphServiceClient _graph;
 
@@ -130,7 +123,7 @@ namespace ManutMap.Services
             var pg = await _graph.Drives[driveId].Items["root"].Children.GetAsync();
             var list = new List<DriveItem>();
 
-            foreach (var suf in JsonSuffixes)
+            foreach (var suf in JsonFileConstants.JsonSuffixes)
             {
                 var arquivos = pg.Value
                     .Where(f => f.File != null &&

--- a/Services/JsonFileConstants.cs
+++ b/Services/JsonFileConstants.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace ManutMap.Services
+{
+    internal static class JsonFileConstants
+    {
+        public static readonly string[] JsonSuffixes =
+        {
+            "__Manutencao_AC2025.json",
+            "__Manutencao_AC2024.json",
+            "__Manutencao_AC2023.json",
+            "__Manutencao_MT.json"
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add `JsonFileConstants` with list of JSON suffixes
- load the latest JSON for each suffix in `SharePointService`
- use same suffix list from `DatalogService`
- handle case-insensitive `manutencoes` property when merging

## Testing
- `dotnet build ManutMap.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f51ec53083339107a70bc1dfeb08