### PR TITLE
Handle datalog cache on startup

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -54,10 +54,14 @@ namespace ManutMap
             _mapService = new MapService(MapView);
             _mapService.InitializeAsync();
 
-            this.Loaded += async (_, __) =>
+            this.Loaded += (_, __) =>
             {
                 LoadLocalAndPopulate();
-                await SyncAndRefresh();
+                _datalogMap = _datalogService.GetCachedDatalogFolders();
+                AnnotateDatalogInfo();
+                ApplyFilters();
+
+                _ = SyncAndRefresh();
                 _updateTimer.Start();
             };
 

--- a/Services/DatalogService.cs
+++ b/Services/DatalogService.cs
@@ -64,6 +64,12 @@ namespace ManutMap.Services
             File.WriteAllText(CachePath, obj.ToString());
         }
 
+        public Dictionary<string, string> GetCachedDatalogFolders()
+        {
+            LoadCache();
+            return _folderCache ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
 
         private readonly GraphServiceClient _graph;
 


### PR DESCRIPTION
## Summary
- expose a method to read cached datalog folders without contacting SharePoint
- load cached datalog info when the main window starts so the count appears immediately
- keep background sync for fresh data

## Testing
- `dotnet build ManutMap.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681bdbd2e48333b790e71da46cc18a