### PR TITLE
Add progress bar for manual synchronization

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -402,11 +402,12 @@
             <wv2:WebView2 Grid.Row="0" x:Name="MapView"/>
 
             <Border Grid.Row="1" Background="Gray" BorderThickness="0,1,0,0" BorderBrush="{StaticResource Border.Default}" Padding="15,10">
-                <WrapPanel Orientation="Horizontal" ItemHeight="20">
-                    <StackPanel Orientation="Horizontal" Margin="0,0,20,0">
-                        <TextBlock Text="Preventivas:" FontWeight="Bold" Margin="0,0,8,0"/>
-                        <TextBlock x:Name="PreventivasStatsText" Text="0 abertas, 0 concluídas"/>
-                    </StackPanel>
+                <StackPanel>
+                    <WrapPanel Orientation="Horizontal" ItemHeight="20">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,20,0">
+                            <TextBlock Text="Preventivas:" FontWeight="Bold" Margin="0,0,8,0"/>
+                            <TextBlock x:Name="PreventivasStatsText" Text="0 abertas, 0 concluídas"/>
+                        </StackPanel>
                     <StackPanel Orientation="Horizontal" Margin="0,0,20,0">
                         <TextBlock Text="Corretivas:" FontWeight="Bold" Margin="0,0,8,0"/>
                         <TextBlock x:Name="CorretivasStatsText" Text="0 abertas, 0 concluídas"/>
@@ -427,7 +428,10 @@
                         <TextBlock Text="Atualizado:" FontWeight="Bold" Margin="0,0,8,0"/>
                         <TextBlock x:Name="LastUpdatedText" Text="--"/>
                     </StackPanel>
-                </WrapPanel>
+                    </WrapPanel>
+                    <ProgressBar x:Name="SyncProgressBar" Height="10" Visibility="Collapsed" Margin="0,5,0,0"/>
+                    <TextBlock x:Name="SyncProgressText" FontStyle="Italic" Visibility="Collapsed" Margin="0,5,0,0"/>
+                </StackPanel>
             </Border>
         </Grid>
     </Grid>


### PR DESCRIPTION
## Summary
- show a progress bar and status text when clicking **Sincronizar**
- update `SyncAndRefresh` to report progress messages

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681e0754e88333b7c590053152ae56