### PR TITLE
Update date handling to Brazilian format

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -1,5 +1,7 @@
 ﻿using System.Configuration;
 using System.Data;
+using System.Globalization;
+using System.Threading;
 using System.Windows;
 
 namespace ManutMap
@@ -9,6 +11,13 @@ namespace ManutMap
     /// </summary>
     public partial class App : Application
     {
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+            var culture = new CultureInfo("pt-BR");
+            Thread.CurrentThread.CurrentCulture = culture;
+            Thread.CurrentThread.CurrentUICulture = culture;
+        }
     }
 
 }

--- a/DatalogWindow.xaml
+++ b/DatalogWindow.xaml
@@ -141,7 +141,7 @@
                 <DataGridTextColumn Header="OS" Binding="{Binding NumOS}" Width="*"/>
                 <DataGridTextColumn Header="IDSIGFI" Binding="{Binding IdSigfi}" Width="*"/>
                 <DataGridTextColumn Header="ROTA" Binding="{Binding Rota}" Width="*"/>
-                <DataGridTextColumn Header="DATA" Binding="{Binding Data, StringFormat='dd/MM/yyyy'}" Width="*"/>
+                <DataGridTextColumn Header="DATA" Binding="{Binding Data, StringFormat='dd/MM/yyyy HH:mm'}" Width="*"/>
                 <DataGridTextColumn Header="STATUS" Binding="{Binding Status}" Width="*"/>
                 <DataGridTemplateColumn Header="PASTA" Width="Auto">
                     <DataGridTemplateColumn.CellTemplate>

--- a/Helpers/MapHtmlHelper.cs
+++ b/Helpers/MapHtmlHelper.cs
@@ -34,6 +34,25 @@ namespace ManutMap.Helpers
     var markerGroup = L.markerClusterGroup();
     map.addLayer(markerGroup);
 
+    function fmtDate(str){
+      if(!str) return '';
+      var d = new Date(str.replace(' ', 'T'));
+      if(isNaN(d.getTime())){
+        var m = str.match(/(\d{1,2})\/(\d{1,2})\/(\d{4})(?:\s*(\d{1,2}):(\d{1,2}))?/);
+        if(m){
+          var day = parseInt(m[1]), mon = parseInt(m[2])-1,
+              yr = parseInt(m[3]), hh = m[4]?parseInt(m[4]):0,
+              mm = m[5]?parseInt(m[5]):0;
+          d = new Date(yr, mon, day, hh, mm);
+        } else return str;
+      }
+      return ('0'+d.getDate()).slice(-2)+'/'+
+             ('0'+(d.getMonth()+1)).slice(-2)+'/'+
+             d.getFullYear()+' '+
+             ('0'+d.getHours()).slice(-2)+':'+
+             ('0'+d.getMinutes()).slice(-2);
+    }
+
     function clearMarkers(){
       markerGroup.clearLayers();
     }
@@ -42,8 +61,8 @@ namespace ManutMap.Helpers
       clearMarkers();
 
       data.forEach(function(item) {
-        var dtRec = item.DTAHORARECLAMACAO ? item.DTAHORARECLAMACAO.trim() : '';
-        var dtCon = item.DTCONCLUSAO     ? item.DTCONCLUSAO.trim()     : '';
+        var dtRec = item.DTAHORARECLAMACAO ? fmtDate(item.DTAHORARECLAMACAO.trim()) : '';
+        var dtCon = item.DTCONCLUSAO     ? fmtDate(item.DTCONCLUSAO.trim())     : '';
         var isOpen   = dtRec !== '' && dtCon === '';
         var isClosed = dtCon !== '';
         if ((isOpen && !showOpen) || (isClosed && !showClosed)) return;
@@ -97,8 +116,8 @@ namespace ManutMap.Helpers
       clearMarkers();
 
       data.forEach(function(item){
-        var dtRec = item.DTAHORARECLAMACAO ? item.DTAHORARECLAMACAO.trim() : '';
-        var dtCon = item.DTCONCLUSAO     ? item.DTCONCLUSAO.trim()     : '';
+        var dtRec = item.DTAHORARECLAMACAO ? fmtDate(item.DTAHORARECLAMACAO.trim()) : '';
+        var dtCon = item.DTCONCLUSAO     ? fmtDate(item.DTCONCLUSAO.trim())     : '';
         var isOpen   = dtRec !== '' && dtCon === '';
         var isClosed = dtCon !== '';
         if((isOpen && !showOpen) || (isClosed && !showClosed)) return;
@@ -157,8 +176,8 @@ namespace ManutMap.Helpers
       clearMarkers();
 
       data.forEach(function(item){
-        var dtRec = item.DTAHORARECLAMACAO ? item.DTAHORARECLAMACAO.trim() : '';
-        var dtCon = item.DTCONCLUSAO     ? item.DTCONCLUSAO.trim()     : '';
+        var dtRec = item.DTAHORARECLAMACAO ? fmtDate(item.DTAHORARECLAMACAO.trim()) : '';
+        var dtCon = item.DTCONCLUSAO     ? fmtDate(item.DTCONCLUSAO.trim())     : '';
         var isOpen   = dtRec !== '' && dtCon === '';
         var isClosed = dtCon !== '';
         if((isOpen && !showOpen) || (isClosed && !showClosed)) return;
@@ -215,8 +234,8 @@ namespace ManutMap.Helpers
       clearMarkers();
 
       data.forEach(function(item){
-        var dtRec = item.DTAHORARECLAMACAO ? item.DTAHORARECLAMACAO.trim() : '';
-        var dtCon = item.DTCONCLUSAO     ? item.DTCONCLUSAO.trim()     : '';
+        var dtRec = item.DTAHORARECLAMACAO ? fmtDate(item.DTAHORARECLAMACAO.trim()) : '';
+        var dtCon = item.DTCONCLUSAO     ? fmtDate(item.DTCONCLUSAO.trim())     : '';
         var isOpen   = dtRec !== '' && dtCon === '';
         var isClosed = dtCon !== '';
         if((isOpen && !showOpen) || (isClosed && !showClosed)) return;
@@ -298,8 +317,8 @@ namespace ManutMap.Helpers
       });
 
       data.forEach(function(item){
-        var dtRec = item.DTAHORARECLAMACAO ? item.DTAHORARECLAMACAO.trim() : '';
-        var dtCon = item.DTCONCLUSAO     ? item.DTCONCLUSAO.trim()     : '';
+        var dtRec = item.DTAHORARECLAMACAO ? fmtDate(item.DTAHORARECLAMACAO.trim()) : '';
+        var dtCon = item.DTCONCLUSAO     ? fmtDate(item.DTCONCLUSAO.trim())     : '';
         var isOpen   = dtRec !== '' && dtCon === '';
         var isClosed = dtCon !== '';
         if((isOpen && !showOpen) || (isClosed && !showClosed)) return;

--- a/Services/DatalogService.cs
+++ b/Services/DatalogService.cs
@@ -324,8 +324,8 @@ namespace ManutMap.Services
                     var dtStr = t.Value<string>("DATACONCLUSAO");
                     if (string.IsNullOrWhiteSpace(dtStr)) continue;
 
-                    var dt = DateTime.Parse(dtStr, CultureInfo.InvariantCulture,
-                                            DateTimeStyles.AssumeUniversal);
+                    var pt = CultureInfo.GetCultureInfo("pt-BR");
+                    var dt = DateTime.Parse(dtStr, pt, DateTimeStyles.AssumeUniversal);
                     if (dt < ini || dt > fim) continue;
                     dataJson = dt;
                 }
@@ -340,8 +340,9 @@ namespace ManutMap.Services
                     };
                     if (!ok) continue;
 
+                    var pt = CultureInfo.GetCultureInfo("pt-BR");
                     if (DateTime.TryParse(t.Value<string>("DATACONCLUSAO"),
-                                          CultureInfo.InvariantCulture,
+                                          pt,
                                           DateTimeStyles.AssumeUniversal, out var dtTmp))
                         dataJson = dtTmp;
                 }

--- a/Services/FilterService.cs
+++ b/Services/FilterService.cs
@@ -74,8 +74,9 @@ namespace ManutMap.Services
                     if (c.StartDate.HasValue || c.EndDate.HasValue)
                     {
                         DateTime dt;
-                        if ((isOpen && DateTime.TryParse(dtRec, out dt)) ||
-                            (isClosed && DateTime.TryParse(dtCon, out dt)))
+                        var pt = System.Globalization.CultureInfo.GetCultureInfo("pt-BR");
+                        if ((isOpen && DateTime.TryParse(dtRec, pt, System.Globalization.DateTimeStyles.None, out dt)) ||
+                            (isClosed && DateTime.TryParse(dtCon, pt, System.Globalization.DateTimeStyles.None, out dt)))
                         {
                             if (c.StartDate.HasValue && dt < c.StartDate.Value) return false;
                             if (c.EndDate.HasValue && dt > c.EndDate.Value) return false;


### PR DESCRIPTION
## Summary
- set app culture to `pt-BR`
- ensure date filters parse using `pt-BR` culture
- format datalog list grid with Brazilian date/time
- format dates in map popup using new `fmtDate` helper

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686824072f008333ab0be1bc72832724