### PR TITLE
Add marker style filter

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -409,6 +409,21 @@
 
                                     <Separator Margin="0,0,0,15"/>
 
+                                    <TextBlock Text="Tipo de Marcador:" Style="{StaticResource LabelStyle}"/>
+                                    <ComboBox x:Name="MarkerStyleCombo" SelectionChanged="FiltersChanged" SelectedIndex="0">
+                                        <ComboBoxItem Content="Círculo" Tag="circle"/>
+                                        <ComboBoxItem Content="Azul" Tag="blue"/>
+                                        <ComboBoxItem Content="Vermelho" Tag="red"/>
+                                        <ComboBoxItem Content="Verde" Tag="green"/>
+                                        <ComboBoxItem Content="Laranja" Tag="orange"/>
+                                        <ComboBoxItem Content="Amarelo" Tag="yellow"/>
+                                        <ComboBoxItem Content="Roxo" Tag="violet"/>
+                                        <ComboBoxItem Content="Cinza" Tag="grey"/>
+                                        <ComboBoxItem Content="Preto" Tag="black"/>
+                                    </ComboBox>
+
+                                    <Separator Margin="0,0,0,15"/>
+
                                     <TextBlock Text="Campo de Coordenadas:" Style="{StaticResource LabelStyle}"/>
                                     <ComboBox x:Name="LatLonFieldCombo" SelectionChanged="FiltersChanged" SelectedIndex="0">
                                         <ComboBoxItem Content="LATLON"/>

--- a/Models/FilterCriteria.cs
+++ b/Models/FilterCriteria.cs
@@ -32,6 +32,9 @@ namespace ManutMap.Models
         // "LATLON" ou "LATLONCON"
         public string LatLonField { get; set; } = "LATLON";
 
+        // Novo: tipo de marcador (circle, blue, red ...)
+        public string MarkerStyle { get; set; } = "circle";
+
         // Exibir apenas itens com datalog disponível
         public bool OnlyDatalog { get; set; }
     }

--- a/Services/MapService.cs
+++ b/Services/MapService.cs
@@ -126,5 +126,21 @@ namespace ManutMap.Services
             else
                 _view.ExecuteScriptAsync(script);
         }
+
+        public void AddMarkersCustomIcon(IEnumerable<JObject> data,
+                                          bool showOpen,
+                                          bool showClosed,
+                                          string iconUrl,
+                                          string latLonField = "LATLON")
+        {
+            var json = JsonConvert.SerializeObject(data);
+            var script =
+                $"addMarkersCustomIcon({json},{showOpen.ToString().ToLower()},{showClosed.ToString().ToLower()},'{iconUrl}','{latLonField}');";
+
+            if (!_ready)
+                _pendingScripts.Add(script);
+            else
+                _view.ExecuteScriptAsync(script);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add marker style combo in the UI with several colored icons
- support marker style field in filter criteria
- update map service and HTML helper to render custom icons
- allow exporting HTML with selected marker style

## Testing
- `dotnet build -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686970fe79588333b6402a9069e55910