### PR TITLE
Add clustering toggle

### DIFF
--- a/Helpers/MapHtmlHelper.cs
+++ b/Helpers/MapHtmlHelper.cs
@@ -34,6 +34,14 @@ namespace ManutMap.Helpers
     var markerGroup = L.markerClusterGroup();
     map.addLayer(markerGroup);
 
+    function setClustering(enabled){
+      if(markerGroup){
+        map.removeLayer(markerGroup);
+      }
+      markerGroup = enabled ? L.markerClusterGroup() : L.layerGroup();
+      map.addLayer(markerGroup);
+    }
+
     function fmtDate(str){
       if(!str) return '';
       var d = new Date(str.replace(' ', 'T'));
@@ -457,7 +465,8 @@ namespace ManutMap.Helpers
                                              bool colorServOn,
                                              string latLonField,
                                              bool iconByTipo = false,
-                                             string? customIcon = null)
+                                             string? customIcon = null,
+                                             bool useClusters = true)
         {
             var baseHtml = GetHtml();
             var json = JsonConvert.SerializeObject(data);
@@ -468,7 +477,7 @@ namespace ManutMap.Helpers
                 call = $"addMarkersByTipoServicoIcon(data,{showOpen.ToString().ToLower()},{showClosed.ToString().ToLower()},'{latLonField}');";
             else
                 call = $"addMarkersSelective(data,{showOpen.ToString().ToLower()},{showClosed.ToString().ToLower()},'{colorOpen}','{colorClosed}','{colorPrev}','{colorCorr}','{colorServ}',{colorPrevOn.ToString().ToLower()},{colorCorrOn.ToString().ToLower()},{colorServOn.ToString().ToLower()},'{latLonField}');";
-            var script = $"<script>var data = {json};window.onload=function(){{{call}}}</script>";
+            var script = $"<script>var data = {json};window.onload=function(){{setClustering({useClusters.ToString().ToLower()});{call}}}</script>";
             return baseHtml.Replace("</body></html>", script + "</body></html>");
         }
     }

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -437,6 +437,8 @@
                                         <ComboBoxItem Content="LATLON"/>
                                         <ComboBoxItem Content="LATLONCON"/>
                                     </ComboBox>
+                                    <CheckBox x:Name="ChbCluster" Content="Agrupar Marcadores" IsChecked="True"
+                                              Margin="0,10,0,0" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
                                 </StackPanel>
                             </Expander>
                         </Border>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -104,6 +104,8 @@ namespace ManutMap
             ColorTipoCorrCombo.SelectionChanged += FiltersChanged;
             ColorTipoServCombo.SelectionChanged += FiltersChanged;
             MarkerStyleCombo.SelectionChanged += FiltersChanged;
+            ChbCluster.Checked += FiltersChanged;
+            ChbCluster.Unchecked += FiltersChanged;
         }
 
         private void LoadLocalAndPopulate()
@@ -249,7 +251,8 @@ namespace ManutMap
                 ColorServicoOutros = (ColorTipoServCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#008080",
                 LatLonField = (LatLonFieldCombo.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? "LATLON",
                 MarkerStyle = (MarkerStyleCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "circle",
-                OnlyDatalog = ChbOnlyDatalog.IsChecked == true
+                OnlyDatalog = ChbOnlyDatalog.IsChecked == true,
+                UseClusters = ChbCluster.IsChecked != false
             };
         }
 
@@ -272,6 +275,8 @@ namespace ManutMap
             if (_manutList == null) return;
 
             var criteria = GetCurrentCriteria();
+
+            _mapService.SetClustering(criteria.UseClusters);
 
             var filteredResult = _filterSvc.Apply(_manutList, criteria);
 
@@ -449,7 +454,8 @@ namespace ManutMap
                                                                 criteria.ColorServOn,
                                                                 criteria.LatLonField,
                                                                 false,
-                                                                icon);
+                                                                icon,
+                                                                criteria.UseClusters);
 
                 var dialog = new SaveFileDialog
                 {

--- a/Models/FilterCriteria.cs
+++ b/Models/FilterCriteria.cs
@@ -37,6 +37,9 @@ namespace ManutMap.Models
 
         // Exibir apenas itens com datalog disponível
         public bool OnlyDatalog { get; set; }
+
+        // Novo: habilitar agrupamento de marcadores
+        public bool UseClusters { get; set; } = true;
     }
 }
 

--- a/Services/MapService.cs
+++ b/Services/MapService.cs
@@ -32,6 +32,15 @@ namespace ManutMap.Services
             _view.NavigateToString(MapHtmlHelper.GetHtml());
         }
 
+        public void SetClustering(bool enabled)
+        {
+            var script = $"setClustering({enabled.ToString().ToLower()});";
+            if (!_ready)
+                _pendingScripts.Add(script);
+            else
+                _view.ExecuteScriptAsync(script);
+        }
+
         public void AddMarkers(IEnumerable<JObject> data,
                                bool showOpen,
                                bool showClosed,


### PR DESCRIPTION
## Summary
- add toggle to cluster map markers
- propagate clustering setting through data models and JS

## Testing
- `dotnet build ManutMap.sln -clp:ErrorsOnly` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869752d68188333b9ddba9174b24629