### PR TITLE
Improve prazo panel with IDSIGFI filter

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -544,5 +544,32 @@ namespace ManutMap
             win.Owner = this;
             win.Show();
         }
+
+        public void ShowClientOnMap(string idSigfi)
+        {
+            if (_manutList == null || string.IsNullOrWhiteSpace(idSigfi)) return;
+
+            var entries = _manutList
+                .OfType<JObject>()
+                .Where(o => string.Equals((o["IDSIGFI"]?.ToString() ?? string.Empty).Trim(),
+                                        idSigfi.Trim(), StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            if (entries.Count == 0) return;
+
+            var criteria = GetCurrentCriteria();
+            _mapService.SetClustering(false);
+            _mapService.AddMarkersSelective(entries,
+                                            criteria.ShowOpen,
+                                            criteria.ShowClosed,
+                                            criteria.ColorOpen,
+                                            criteria.ColorClosed,
+                                            criteria.ColorServicoPreventiva,
+                                            criteria.ColorServicoCorretiva,
+                                            criteria.ColorServicoOutros,
+                                            criteria.ColorPrevOn,
+                                            criteria.ColorCorrOn,
+                                            criteria.ColorServOn,
+                                            criteria.LatLonField);
+        }
     }
 }

--- a/PrazoWindow.xaml
+++ b/PrazoWindow.xaml
@@ -12,21 +12,42 @@
                           LoadingRow="GridCorretivas_LoadingRow">
                     <DataGrid.Columns>
                         <DataGridTextColumn Header="OS" Binding="{Binding NumOS}" Width="*"/>
+                        <DataGridTextColumn Header="ID SIGFI" Binding="{Binding IdSigfi}" Width="*"/>
                         <DataGridTextColumn Header="Cliente" Binding="{Binding Cliente}" Width="2*"/>
                         <DataGridTextColumn Header="Abertura" Binding="{Binding Abertura, StringFormat='dd/MM/yyyy'}" Width="*"/>
                         <DataGridTextColumn Header="Dias Restantes" Binding="{Binding DiasRestantes}" Width="*"/>
+                        <DataGridTemplateColumn Header="Mapa" Width="Auto">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <Button Content="Mapa" Padding="4,2" Margin="2"
+                                            Click="MapaCorretiva_Click"
+                                            Tag="{Binding IdSigfi}"/>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
                     </DataGrid.Columns>
                 </DataGrid>
             </TabItem>
             <TabItem Header="Preventivas">
-                <DataGrid x:Name="GridPreventivas" AutoGenerateColumns="False" Margin="0,5" 
-                          IsReadOnly="True" AlternatingRowBackground="#eeeeee" 
+                <DataGrid x:Name="GridPreventivas" AutoGenerateColumns="False" Margin="0,5"
+                          IsReadOnly="True" AlternatingRowBackground="#eeeeee"
                           LoadingRow="GridPreventivas_LoadingRow">
                     <DataGrid.Columns>
+                        <DataGridTextColumn Header="OS" Binding="{Binding NumOS}" Width="*"/>
+                        <DataGridTextColumn Header="ID SIGFI" Binding="{Binding IdSigfi}" Width="*"/>
                         <DataGridTextColumn Header="Cliente" Binding="{Binding Cliente}" Width="2*"/>
                         <DataGridTextColumn Header="Última" Binding="{Binding Ultima, StringFormat='dd/MM/yyyy'}" Width="*"/>
                         <DataGridTextColumn Header="Próxima" Binding="{Binding Proxima, StringFormat='dd/MM/yyyy'}" Width="*"/>
                         <DataGridTextColumn Header="Dias Restantes" Binding="{Binding DiasRestantes}" Width="*"/>
+                        <DataGridTemplateColumn Header="Mapa" Width="Auto">
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <Button Content="Mapa" Padding="4,2" Margin="2"
+                                            Click="MapaPreventiva_Click"
+                                            Tag="{Binding IdSigfi}"/>
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
                     </DataGrid.Columns>
                 </DataGrid>
             </TabItem>

--- a/PrazoWindow.xaml.cs
+++ b/PrazoWindow.xaml.cs
@@ -14,6 +14,7 @@ namespace ManutMap
         public class CorretivaInfo
         {
             public string NumOS { get; set; } = string.Empty;
+            public string IdSigfi { get; set; } = string.Empty;
             public string Cliente { get; set; } = string.Empty;
             public DateTime Abertura { get; set; }
             public int DiasRestantes { get; set; }
@@ -21,6 +22,8 @@ namespace ManutMap
 
         public class PreventivaInfo
         {
+            public string NumOS { get; set; } = string.Empty;
+            public string IdSigfi { get; set; } = string.Empty;
             public string Cliente { get; set; } = string.Empty;
             public DateTime Ultima { get; set; }
             public DateTime Proxima { get; set; }
@@ -52,6 +55,7 @@ namespace ManutMap
                     list.Add(new CorretivaInfo
                     {
                         NumOS = obj["NUMOS"]?.ToString() ?? string.Empty,
+                        IdSigfi = obj["IDSIGFI"]?.ToString() ?? string.Empty,
                         Cliente = obj["NOMECLIENTE"]?.ToString() ?? string.Empty,
                         Abertura = dt,
                         DiasRestantes = diasRest
@@ -63,7 +67,7 @@ namespace ManutMap
 
         private static List<PreventivaInfo> GetPreventivas(JArray dados)
         {
-            var dict = new Dictionary<string, (DateTime dt, string cliente)>();
+            var dict = new Dictionary<string, (DateTime dt, string cliente, string numOs, string idSigfi)>();
             var pt = CultureInfo.GetCultureInfo("pt-BR");
             foreach (JObject obj in dados.OfType<JObject>())
             {
@@ -81,8 +85,10 @@ namespace ManutMap
                 if (id == string.Empty)
                     continue;
                 string cliente = obj["NOMECLIENTE"]?.ToString() ?? id;
+                string numOs = obj["NUMOS"]?.ToString() ?? string.Empty;
+                string idSigfi = obj["IDSIGFI"]?.ToString() ?? string.Empty;
                 if (!dict.ContainsKey(id) || dict[id].dt < dt)
-                    dict[id] = (dt, cliente);
+                    dict[id] = (dt, cliente, numOs, idSigfi);
             }
             var list = new List<PreventivaInfo>();
             foreach (var kv in dict)
@@ -91,6 +97,8 @@ namespace ManutMap
                 int dias = (int)Math.Ceiling((proxima.Date - DateTime.Today).TotalDays);
                 list.Add(new PreventivaInfo
                 {
+                    NumOS = kv.Value.numOs,
+                    IdSigfi = kv.Value.idSigfi,
                     Cliente = kv.Value.cliente,
                     Ultima = kv.Value.dt,
                     Proxima = proxima,
@@ -117,6 +125,24 @@ namespace ManutMap
                 e.Row.Background = info.DiasRestantes <= 0 ? Brushes.IndianRed :
                                     info.DiasRestantes <= 30 ? Brushes.Orange :
                                     Brushes.LightGreen;
+            }
+        }
+
+        private void MapaCorretiva_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button btn && btn.Tag is string id && Owner is MainWindow mw)
+            {
+                mw.ShowClientOnMap(id);
+                mw.Activate();
+            }
+        }
+
+        private void MapaPreventiva_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is Button btn && btn.Tag is string id && Owner is MainWindow mw)
+            {
+                mw.ShowClientOnMap(id);
+                mw.Activate();
             }
         }
     }


### PR DESCRIPTION
## Summary
- show IDSIGFI and OS on prazo tables
- group preventivas by IDSIGFI when calculating next date
- add buttons to open client's location on the map
- expose ShowClientOnMap method in MainWindow

## Testing
- `dotnet build -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686977542c5c8333af2c6c5850b77cf2