### PR TITLE
Add regional filters to Prazo panel and improve map info

### DIFF
--- a/Helpers/MapHtmlHelper.cs
+++ b/Helpers/MapHtmlHelper.cs
@@ -98,6 +98,10 @@ namespace ManutMap.Helpers
         var temDat = item.TemDatalog || item.TEMDATALOG || false;
         var datUrl = item.FolderUrl || item.FOLDERURL || '';
         var descExec = item.DESCADICIONALEXEC || '';
+        var prevUlt = item.PREV_ULTIMA ? fmtDate(item.PREV_ULTIMA) : '';
+        var prevProx = item.PREV_PROXIMA ? fmtDate(item.PREV_PROXIMA) : '';
+        var prevDias = item.PREV_DIAS;
+        var corrDias = item.CORR_DIAS;
 
         var popup = '<b>OS:</b> '+item.NUMOS+'<br>'+
                     '<b>Cliente:</b> '+item.NOMECLIENTE+'<br>'+
@@ -111,6 +115,9 @@ namespace ManutMap.Helpers
                     '<b>Serviço:</b> '+item.TIPO+'<br>'+
                     '<b>Datalog:</b> '+(temDat?'Sim':'Não')+'<br>'+
                     (datUrl?'<a href="'+datUrl+'" target="_blank">Abrir Datalog</a><br>':'')+
+                    (prevUlt?'<b>Última Prev.:</b> '+prevUlt+'<br>':'')+
+                    (prevProx?'<b>Próxima Prev.:</b> '+prevProx+' <span style="color:'+(prevDias<=0?'IndianRed':(prevDias<=30?'Orange':'Green'))+'">('+prevDias+' dias)</span><br>':'')+
+                    (corrDias!==undefined?'<b>Corretiva SLA:</b> <span style="color:'+(corrDias<=0?'IndianRed':(corrDias<=2?'Orange':'Green'))+'">'+corrDias+' dias</span><br>':'')+
                     (isClosed?'<b>DESCADICIONALEXEC:</b> '+descExec+'<br>':'')+
                     '<b>LatLon ('+latLonField+'):</b> '+coordStr;
 
@@ -173,6 +180,9 @@ namespace ManutMap.Helpers
                     '<b>Serviço:</b> '+item.TIPO+'<br>'+
                     '<b>Datalog:</b> '+(temDat?'Sim':'Não')+'<br>'+
                     (datUrl?'<a href="'+datUrl+'" target="_blank">Abrir Datalog</a><br>':'')+
+                    (prevUlt?'<b>Última Prev.:</b> '+prevUlt+'<br>':'')+
+                    (prevProx?'<b>Próxima Prev.:</b> '+prevProx+' <span style="color:'+(prevDias<=0?'IndianRed':(prevDias<=30?'Orange':'Green'))+'">('+prevDias+' dias)</span><br>':'')+
+                    (corrDias!==undefined?'<b>Corretiva SLA:</b> <span style="color:'+(corrDias<=0?'IndianRed':(corrDias<=2?'Orange':'Green'))+'">'+corrDias+' dias</span><br>':'')+
                     (isClosed?'<b>DESCADICIONALEXEC:</b> '+descExec+'<br>':'')+
                     '<b>LatLon ('+latLonField+'):</b> '+coordStr;
 
@@ -233,6 +243,9 @@ namespace ManutMap.Helpers
                     '<b>Serviço:</b> '+item.TIPO+'<br>'+
                     '<b>Datalog:</b> '+(temDat?'Sim':'Não')+'<br>'+
                     (datUrl?'<a href="'+datUrl+'" target="_blank">Abrir Datalog</a><br>':'')+
+                    (prevUlt?'<b>Última Prev.:</b> '+prevUlt+'<br>':'')+
+                    (prevProx?'<b>Próxima Prev.:</b> '+prevProx+' <span style="color:'+(prevDias<=0?'IndianRed':(prevDias<=30?'Orange':'Green'))+'">('+prevDias+' dias)</span><br>':'')+
+                    (corrDias!==undefined?'<b>Corretiva SLA:</b> <span style="color:'+(corrDias<=0?'IndianRed':(corrDias<=2?'Orange':'Green'))+'">'+corrDias+' dias</span><br>':'')+
                     (isClosed?'<b>DESCADICIONALEXEC:</b> '+descExec+'<br>':'')+
                     '<b>LatLon ('+latLonField+'):</b> '+coordStr;
 
@@ -293,6 +306,9 @@ namespace ManutMap.Helpers
                     '<b>Serviço:</b> '+item.TIPO+'<br>'+
                     '<b>Datalog:</b> '+(temDat?'Sim':'Não')+'<br>'+
                     (datUrl?'<a href="'+datUrl+'" target="_blank">Abrir Datalog</a><br>':'')+
+                    (prevUlt?'<b>Última Prev.:</b> '+prevUlt+'<br>':'')+
+                    (prevProx?'<b>Próxima Prev.:</b> '+prevProx+' <span style="color:'+(prevDias<=0?'IndianRed':(prevDias<=30?'Orange':'Green'))+'">('+prevDias+' dias)</span><br>':'')+
+                    (corrDias!==undefined?'<b>Corretiva SLA:</b> <span style="color:'+(corrDias<=0?'IndianRed':(corrDias<=2?'Orange':'Green'))+'">'+corrDias+' dias</span><br>':'')+
                     (isClosed?'<b>DESCADICIONALEXEC:</b> '+descExec+'<br>':'')+
                     '<b>LatLon ('+latLonField+'):</b> '+coordStr;
 
@@ -375,6 +391,9 @@ namespace ManutMap.Helpers
                     '<b>Serviço:</b> '+item.TIPO+'<br>'+
                     '<b>Datalog:</b> '+(temDat?'Sim':'Não')+'<br>'+
                     (datUrl?'<a href="'+datUrl+'" target="_blank">Abrir Datalog</a><br>':'')+
+                    (prevUlt?'<b>Última Prev.:</b> '+prevUlt+'<br>':'')+
+                    (prevProx?'<b>Próxima Prev.:</b> '+prevProx+' <span style="color:'+(prevDias<=0?'IndianRed':(prevDias<=30?'Orange':'Green'))+'">('+prevDias+' dias)</span><br>':'')+
+                    (corrDias!==undefined?'<b>Corretiva SLA:</b> <span style="color:'+(corrDias<=0?'IndianRed':(corrDias<=2?'Orange':'Green'))+'">'+corrDias+' dias</span><br>':'')+
                     (isClosed?'<b>DESCADICIONALEXEC:</b> '+descExec+'<br>':'')+
                     '<b>LatLon ('+latLonField+'):</b> '+coordStr;
 
@@ -437,6 +456,9 @@ namespace ManutMap.Helpers
                     '<b>Serviço:</b> '+item.TIPO+'<br>'+
                     '<b>Datalog:</b> '+(temDat?'Sim':'Não')+'<br>'+
                     (datUrl?'<a href="'+datUrl+'" target="_blank">Abrir Datalog</a><br>':'')+
+                    (prevUlt?'<b>Última Prev.:</b> '+prevUlt+'<br>':'')+
+                    (prevProx?'<b>Próxima Prev.:</b> '+prevProx+' <span style="color:'+(prevDias<=0?'IndianRed':(prevDias<=30?'Orange':'Green'))+'">('+prevDias+' dias)</span><br>':'')+
+                    (corrDias!==undefined?'<b>Corretiva SLA:</b> <span style="color:'+(corrDias<=0?'IndianRed':(corrDias<=2?'Orange':'Green'))+'">'+corrDias+' dias</span><br>':'')+
                     (isClosed?'<b>DESCADICIONALEXEC:</b> '+descExec+'<br>':'')+
                     '<b>LatLon ('+latLonField+'):</b> '+coordStr;
 

--- a/PrazoWindow.xaml
+++ b/PrazoWindow.xaml
@@ -5,7 +5,24 @@
         Title="Painel de Prazos" Height="600" Width="900"
         WindowStartupLocation="CenterOwner" Background="#f0f0f0">
     <Grid Margin="10">
-        <TabControl>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,10" Grid.Row="0">
+            <StackPanel Margin="0,0,20,0">
+                <TextBlock Text="Regional"/>
+                <ComboBox x:Name="RegionalFilterCombo" Width="150" SelectionChanged="RegionalChanged"/>
+            </StackPanel>
+            <StackPanel Margin="0,0,20,0">
+                <TextBlock Text="Rota"/>
+                <ComboBox x:Name="RotaFilterCombo" Width="80" SelectionChanged="FiltersChanged"/>
+            </StackPanel>
+            <Button x:Name="ShowFilteredButton" Content="Mostrar no Mapa" Padding="10,4" Margin="0,18,0,0" Click="ShowFilteredButton_Click"/>
+        </StackPanel>
+
+        <TabControl Grid.Row="1">
             <TabItem Header="Corretivas">
                 <DataGrid x:Name="GridCorretivas" AutoGenerateColumns="False" Margin="0,5" 
                           IsReadOnly="True" AlternatingRowBackground="#eeeeee" 


### PR DESCRIPTION
## Summary
- annotate preventive and corrective info for popups
- add method to show several clients on the map
- enhance map popups with preventive/corrective deadlines
- add regional/rota filters to PrazoWindow with button

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68697d9e43148333bfea7d390b06f336