### PR TITLE
Add prazo filters

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -443,6 +443,30 @@
                                 </StackPanel>
                             </Expander>
                         </Border>
+
+                        <Border Style="{StaticResource Card}">
+                            <Expander Header="Prazos" IsExpanded="False">
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <StackPanel Grid.Column="0" Margin="0,0,10,0">
+                                        <TextBlock Text="Dias" Style="{StaticResource LabelStyle}"/>
+                                        <TextBox x:Name="PrazoDiasTextBox" PreviewTextInput="PrazoDiasTextBox_PreviewTextInput" TextChanged="FiltersChanged"/>
+                                    </StackPanel>
+                                    <StackPanel Grid.Column="1">
+                                        <TextBlock Text="Tipo de Prazo" Style="{StaticResource LabelStyle}"/>
+                                        <ComboBox x:Name="TipoPrazoCombo" SelectionChanged="FiltersChanged" SelectedIndex="0">
+                                            <ComboBoxItem Content="Todos"/>
+                                            <ComboBoxItem Content="Restantes"/>
+                                            <ComboBoxItem Content="Vencidos"/>
+                                            <ComboBoxItem Content="Exato"/>
+                                        </ComboBox>
+                                    </StackPanel>
+                                </Grid>
+                            </Expander>
+                        </Border>
                     </StackPanel>
                 </ScrollViewer>
             </DockPanel>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows;
+using System.Windows.Input;
 using System.Threading.Tasks;
 using System.Windows.Controls;
 using Microsoft.Win32;
@@ -107,6 +108,10 @@ namespace ManutMap
             MarkerStyleCombo.SelectionChanged += FiltersChanged;
             ChbCluster.Checked += FiltersChanged;
             ChbCluster.Unchecked += FiltersChanged;
+
+            PrazoDiasTextBox.TextChanged += FiltersChanged;
+            PrazoDiasTextBox.PreviewTextInput += PrazoDiasTextBox_PreviewTextInput;
+            TipoPrazoCombo.SelectionChanged += FiltersChanged;
         }
 
         private void LoadLocalAndPopulate()
@@ -256,7 +261,9 @@ namespace ManutMap
                 LatLonField = (LatLonFieldCombo.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? "LATLON",
                 MarkerStyle = (MarkerStyleCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "circle",
                 OnlyDatalog = ChbOnlyDatalog.IsChecked == true,
-                UseClusters = ChbCluster.IsChecked != false
+                UseClusters = ChbCluster.IsChecked != false,
+                PrazoDias = int.TryParse(PrazoDiasTextBox.Text, out var pd) ? pd : 0,
+                TipoPrazo = (TipoPrazoCombo.SelectedItem as ComboBoxItem)?.Content.ToString() ?? "Todos"
             };
         }
 
@@ -590,6 +597,9 @@ namespace ManutMap
             MarkerStyleCombo.SelectedIndex = 0;
             LatLonFieldCombo.SelectedIndex = 0;
 
+            PrazoDiasTextBox.Text = string.Empty;
+            TipoPrazoCombo.SelectedIndex = 0;
+
             ApplyFilters();
         }
 
@@ -613,6 +623,11 @@ namespace ManutMap
             var win = new PrazoWindow(_manutList);
             win.Owner = this;
             win.Show();
+        }
+
+        private void PrazoDiasTextBox_PreviewTextInput(object sender, TextCompositionEventArgs e)
+        {
+            e.Handled = !e.Text.All(char.IsDigit);
         }
 
         public void ShowClientOnMap(string idSigfi)

--- a/Models/FilterCriteria.cs
+++ b/Models/FilterCriteria.cs
@@ -40,6 +40,10 @@ namespace ManutMap.Models
 
         // Novo: habilitar agrupamento de marcadores
         public bool UseClusters { get; set; } = true;
+
+        // Filtro de prazos
+        public int PrazoDias { get; set; }
+        public string TipoPrazo { get; set; } = "Todos";
     }
 }
 

--- a/Services/FilterService.cs
+++ b/Services/FilterService.cs
@@ -84,6 +84,26 @@ namespace ManutMap.Services
                         else return false;
                     }
 
+                    if (c.PrazoDias > 0 && c.TipoPrazo != "Todos")
+                    {
+                        bool has = false;
+                        bool ok = false;
+
+                        if (item["CORR_DIAS"] != null && int.TryParse(item["CORR_DIAS"].ToString(), out var corr))
+                        {
+                            has = true;
+                            ok |= CheckPrazo(corr, c);
+                        }
+                        if (item["PREV_DIAS"] != null && int.TryParse(item["PREV_DIAS"].ToString(), out var prev))
+                        {
+                            has = true;
+                            ok |= CheckPrazo(prev, c);
+                        }
+
+                        if (!has || !ok)
+                            return false;
+                    }
+
                     return true;
                 })
                 .ToList();
@@ -93,6 +113,17 @@ namespace ManutMap.Services
                          StringComparer.OrdinalIgnoreCase)
                 .Select(g => g.First())
                 .ToList();
+        }
+
+        private static bool CheckPrazo(int dias, FilterCriteria c)
+        {
+            return c.TipoPrazo switch
+            {
+                "Restantes" => dias >= 0 && dias <= c.PrazoDias,
+                "Vencidos" => dias < 0 && -dias <= c.PrazoDias,
+                "Exato" => Math.Abs(dias) == c.PrazoDias,
+                _ => true
+            };
         }
     }
 }


### PR DESCRIPTION
## Summary
- add prazo filters to `FilterCriteria`
- support prazo filtering in `FilterService`
- expose prazo options in the main window UI
- wire prazo filter events in code-behind

## Testing
- `dotnet build ManutMap.sln -v:q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686acf5e30e4833396748f1b4b189de5