### PR TITLE
Optimize startup with async loading

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -64,12 +64,12 @@ namespace ManutMap
             };
             _updateTimer.Tick += async (_, __) => await SyncAndRefresh();
 
-            _mapService = new MapService(MapView);
-            _mapService.InitializeAsync();
-
-            this.Loaded += (_, __) =>
+            this.Loaded += async (_, __) =>
             {
-                LoadLocalAndPopulate();
+                _mapService = new MapService(MapView);
+                await _mapService.InitializeAsync();
+
+                await LoadLocalAndPopulateAsync();
                 _datalogMap = _datalogService.GetCachedDatalogFolders();
                 AnnotateDatalogInfo();
                 AnnotatePrazoInfo();
@@ -118,6 +118,24 @@ namespace ManutMap
         {
             var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "manutencoes_latest.json");
             _manutList = _fileService.LoadLocalJson(path) ?? new JArray();
+
+            if (File.Exists(path))
+                LastUpdatedText.Text = File.GetLastWriteTime(path).ToString("dd/MM/yyyy HH:mm");
+
+            PopulateComboBox(SigfiFilterCombo, "TIPODESIGFI");
+            PopulateComboBox(TipoFilterCombo, "TIPO");
+            PopulateComboBox(RotaFilterCombo, "ROTA");
+            PopulateComboBox(RegionalFilterCombo, _regionalRotas.Keys);
+
+            AnnotatePrazoInfo();
+
+            ApplyFilters();
+        }
+
+        private async Task LoadLocalAndPopulateAsync()
+        {
+            var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "manutencoes_latest.json");
+            _manutList = await _fileService.LoadLocalJsonAsync(path) ?? new JArray();
 
             if (File.Exists(path))
                 LastUpdatedText.Text = File.GetLastWriteTime(path).ToString("dd/MM/yyyy HH:mm");

--- a/Services/FileService.cs
+++ b/Services/FileService.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 
 namespace ManutMap.Services
@@ -15,6 +16,14 @@ namespace ManutMap.Services
             var json = File.ReadAllText(filename);
             var root = JObject.Parse(json);
             return (JArray)root["manutencoes"];
+        }
+
+        public async Task<JArray?> LoadLocalJsonAsync(string filename)
+        {
+            if (!File.Exists(filename)) return null;
+            var json = await File.ReadAllTextAsync(filename);
+            var root = JObject.Parse(json);
+            return (JArray?)root["manutencoes"];
         }
 
         public void SaveCsv(IEnumerable<JObject> data, string path, string latLonField = "LATLON")


### PR DESCRIPTION
## Summary
- delay map initialization to window load
- load local data asynchronously
- add async method to read local JSON file

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad1b0fafc833383adb0f985ebf5f5