### PR TITLE
Fix cross-thread access in search button

### DIFF
--- a/FuncionarioWindow.xaml.cs
+++ b/FuncionarioWindow.xaml.cs
@@ -47,10 +47,11 @@ namespace ManutMap
             SearchButton.IsEnabled = false;
             ResultText.Text = "Buscando...";
 
+            var selectedIndex = FieldCombo.SelectedIndex;
             var info = await Task.Run(() =>
             {
                 FuncionarioInfo? local = null;
-                switch (FieldCombo.SelectedIndex)
+                switch (selectedIndex)
                 {
                     case 0: // Matricula
                         var key = input.TrimStart('0');


### PR DESCRIPTION
## Summary
- capture `FieldCombo.SelectedIndex` before spawning a background task

## Testing
- `dotnet build --no-restore` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ae0cb693c8333931d22c72ba0a3b0