### PR TITLE
Add custom bar charts for statistics

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -1,9 +1,10 @@
 ﻿<Application x:Class="ManutMap.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:ManutMap"
+            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+            xmlns:local="clr-namespace:ManutMap"
+            xmlns:helpers="clr-namespace:ManutMap.Helpers"
              StartupUri="LoginWindow.xaml">
     <Application.Resources>
-         
+        <helpers:ProportionalHeightConverter x:Key="BarHeightConverter"/>
     </Application.Resources>
 </Application>

--- a/Controls/BarChartControl.xaml
+++ b/Controls/BarChartControl.xaml
@@ -1,0 +1,29 @@
+<UserControl x:Class="ManutMap.Controls.BarChartControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:ManutMap.Controls">
+    <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled">
+        <ItemsControl x:Name="ItemsHost" ItemsSource="{Binding Items}">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <StackPanel Orientation="Horizontal"/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel Orientation="Vertical" Margin="5" VerticalAlignment="Bottom">
+                        <Border Background="SteelBlue" Width="25">
+                            <Border.Height>
+                                <MultiBinding Converter="{StaticResource BarHeightConverter}">
+                                    <Binding Path="Value"/>
+                                    <Binding RelativeSource="{RelativeSource AncestorType=UserControl}" Path="Tag"/>
+                                </MultiBinding>
+                            </Border.Height>
+                        </Border>
+                        <TextBlock Text="{Binding Label}" HorizontalAlignment="Center" Margin="0,5,0,0"/>
+                    </StackPanel>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+    </ScrollViewer>
+</UserControl>

--- a/Controls/BarChartControl.xaml.cs
+++ b/Controls/BarChartControl.xaml.cs
@@ -1,0 +1,62 @@
+using System.Collections;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace ManutMap.Controls
+{
+    public partial class BarChartControl : UserControl, INotifyPropertyChanged
+    {
+        public BarChartControl()
+        {
+            InitializeComponent();
+            DataContext = this;
+        }
+
+        private IEnumerable? _items;
+        public IEnumerable? Items
+        {
+            get => _items;
+            set
+            {
+                _items = value;
+                OnPropertyChanged(nameof(Items));
+                UpdateMax();
+            }
+        }
+
+        private double _maxValue;
+        public double MaxValue
+        {
+            get => _maxValue;
+            private set
+            {
+                _maxValue = value;
+                OnPropertyChanged(nameof(MaxValue));
+                this.Tag = _maxValue;
+            }
+        }
+
+        private void UpdateMax()
+        {
+            if (_items == null) { MaxValue = 0; return; }
+            double max = 0;
+            foreach (var item in _items)
+            {
+                var prop = item?.GetType().GetProperty("Value");
+                if (prop != null)
+                {
+                    var valObj = prop.GetValue(item);
+                    if (double.TryParse(valObj?.ToString(), out double v) && v > max)
+                        max = v;
+                }
+            }
+            MaxValue = max;
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void OnPropertyChanged(string name)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}

--- a/Helpers/ProportionalHeightConverter.cs
+++ b/Helpers/ProportionalHeightConverter.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace ManutMap.Helpers
+{
+    public class ProportionalHeightConverter : IMultiValueConverter
+    {
+        public double MaxHeight { get; set; } = 100;
+
+        public object Convert(object[] values, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (values.Length < 2) return 0.0;
+            if (!double.TryParse(values[0]?.ToString(), out double val)) return 0.0;
+            if (!double.TryParse(values[1]?.ToString(), out double max)) return 0.0;
+            if (max <= 0) return 0.0;
+            return val / max * MaxHeight;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object? parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf"
+        xmlns:controls="clr-namespace:ManutMap.Controls"
         mc:Ignorable="d"
         Title="ManutMap – Mapa de Manutenções"
         Height="768" Width="1366"
@@ -527,41 +528,10 @@
                 <ScrollViewer>
                     <StackPanel Margin="15" x:Name="StatsPanel">
                         <TextBlock Text="Coletas de Datalog por Rota" FontWeight="Bold" FontSize="16" Margin="0,0,0,10"/>
-                        <ItemsControl x:Name="RouteStatsList" Margin="0,0,0,15" DataContext="{Binding RelativeSource={RelativeSource AncestorType=TabItem}}">
-                            <ItemsControl.ItemTemplate>
-                                <DataTemplate>
-                                    <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                                        <TextBlock Text="{Binding Route}" Width="80"/>
-                                        <ProgressBar Value="{Binding Count}" Maximum="{Binding ElementName=RouteStatsList, Path=Tag}" Width="200" Height="16" Margin="5,0"/>
-                                        <TextBlock Text="{Binding Count}" Margin="5,0"/>
-                                    </StackPanel>
-                                </DataTemplate>
-                            </ItemsControl.ItemTemplate>
-                        </ItemsControl>
+                        <controls:BarChartControl x:Name="RouteChart" Margin="0,0,0,15" />
 
                         <TextBlock Text="Datalog por Tipo de Serviço" FontWeight="Bold" FontSize="16" Margin="0,10,0,10"/>
-                        <StackPanel Margin="0,0,0,15">
-                            <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                                <TextBlock Text="Prev. com datalog" Width="150"/>
-                                <ProgressBar x:Name="PrevComBar" Width="200" Height="16"/>
-                                <TextBlock x:Name="PrevComText" Margin="5,0"/>
-                            </StackPanel>
-                            <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                                <TextBlock Text="Prev. sem datalog" Width="150"/>
-                                <ProgressBar x:Name="PrevSemBar" Width="200" Height="16"/>
-                                <TextBlock x:Name="PrevSemText" Margin="5,0"/>
-                            </StackPanel>
-                            <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                                <TextBlock Text="Corr. com datalog" Width="150"/>
-                                <ProgressBar x:Name="CorrComBar" Width="200" Height="16"/>
-                                <TextBlock x:Name="CorrComText" Margin="5,0"/>
-                            </StackPanel>
-                            <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
-                                <TextBlock Text="Corr. sem datalog" Width="150"/>
-                                <ProgressBar x:Name="CorrSemBar" Width="200" Height="16"/>
-                                <TextBlock x:Name="CorrSemText" Margin="5,0"/>
-                            </StackPanel>
-                        </StackPanel>
+                        <controls:BarChartControl x:Name="TipoServicoChart" Margin="0,0,0,15" />
 
                         <TextBlock Text="Ordens de Serviço sem Datalog" FontWeight="Bold" FontSize="16" Margin="0,10,0,5"/>
                         <DataGrid x:Name="DatalogMissingGrid" AutoGenerateColumns="False" Height="200">

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -665,20 +665,22 @@ namespace ManutMap
                 .ToList();
 
             MaxRouteCount = _routeStats.Count > 0 ? _routeStats.Max(r => r.Count) : 0;
-            RouteStatsList.Tag = MaxRouteCount;
-            RouteStatsList.ItemsSource = _routeStats;
+            RouteChart.Tag = MaxRouteCount;
+            RouteChart.Items = _routeStats;
 
             int prevCom = withDatalog.Count(o => string.Equals(o["TIPO"]?.ToString()?.Trim(), "PREVENTIVA", StringComparison.OrdinalIgnoreCase));
             int prevSem = withoutDatalog.Count(o => string.Equals(o["TIPO"]?.ToString()?.Trim(), "PREVENTIVA", StringComparison.OrdinalIgnoreCase));
             int corrCom = withDatalog.Count(o => string.Equals(o["TIPO"]?.ToString()?.Trim(), "CORRETIVA", StringComparison.OrdinalIgnoreCase));
             int corrSem = withoutDatalog.Count(o => string.Equals(o["TIPO"]?.ToString()?.Trim(), "CORRETIVA", StringComparison.OrdinalIgnoreCase));
 
-            int maxVal = new[] { prevCom, prevSem, corrCom, corrSem }.Max();
-            PrevComBar.Maximum = PrevSemBar.Maximum = CorrComBar.Maximum = CorrSemBar.Maximum = maxVal;
-            PrevComBar.Value = prevCom; PrevComText.Text = prevCom.ToString();
-            PrevSemBar.Value = prevSem; PrevSemText.Text = prevSem.ToString();
-            CorrComBar.Value = corrCom; CorrComText.Text = corrCom.ToString();
-            CorrSemBar.Value = corrSem; CorrSemText.Text = corrSem.ToString();
+            var tipoData = new List<LabelValue>
+            {
+                new LabelValue("Prev. com", prevCom),
+                new LabelValue("Prev. sem", prevSem),
+                new LabelValue("Corr. com", corrCom),
+                new LabelValue("Corr. sem", corrSem)
+            };
+            TipoServicoChart.Items = tipoData;
 
             _osSemDatalog.Clear();
             foreach (var o in withoutDatalog)

--- a/Models/LabelValue.cs
+++ b/Models/LabelValue.cs
@@ -1,0 +1,4 @@
+namespace ManutMap.Models
+{
+    public record LabelValue(string Label, double Value);
+}


### PR DESCRIPTION
## Summary
- replace progress bars with reusable `BarChartControl`
- implement height calculation via `ProportionalHeightConverter`
- show route and service type statistics using the new chart control

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aea8d37588333a7b7d317a020d807