### PR TITLE
Fix compile item group

### DIFF
--- a/ManutMap.csproj
+++ b/ManutMap.csproj
@@ -6,10 +6,14 @@
 		<ApplicationIcon>ChatGPT-Image-3-de-jul.-de-2025_-09_07_24.ico</ApplicationIcon>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<Compile Include="Services/FileService.cs" />
-		<Compile Include="Services/DatalogService.cs" />
-	</ItemGroup>
+        <ItemGroup>
+                <Compile Include="Services/FileService.cs" />
+                <Compile Include="Services/DatalogService.cs" />
+                <Compile Include="Services/FilterService.cs" />
+                <Compile Include="Services/MapService.cs" />
+                <Compile Include="Services/JsonFileConstants.cs" />
+                <Compile Include="Services/SharePointService.cs" />
+        </ItemGroup>
 
 	<ItemGroup>
 	  <Content Include="ChatGPT-Image-3-de-jul.-de-2025_-09_07_24.ico" />


### PR DESCRIPTION
## Summary
- include all service files in the project to ensure SharePointService is compiled

## Testing
- `dotnet build ManutMap.sln -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686aed7fa7688333b8b18a1d9cafac22