### PR TITLE
Improve statistics tab visuals

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -6,5 +6,6 @@
              StartupUri="LoginWindow.xaml">
     <Application.Resources>
         <helpers:ProportionalHeightConverter x:Key="BarHeightConverter"/>
+        <helpers:ProportionalWidthConverter x:Key="BarWidthConverter"/>
     </Application.Resources>
 </Application>

--- a/Controls/HorizontalBarChartControl.xaml
+++ b/Controls/HorizontalBarChartControl.xaml
@@ -1,0 +1,23 @@
+<UserControl x:Class="ManutMap.Controls.HorizontalBarChartControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:ManutMap.Controls">
+    <ItemsControl x:Name="ItemsHost" ItemsSource="{Binding Items}">
+        <ItemsControl.ItemTemplate>
+            <DataTemplate>
+                <StackPanel Orientation="Horizontal" Margin="0,5" VerticalAlignment="Center">
+                    <TextBlock Text="{Binding Label}" Width="120"/>
+                    <Border Background="SteelBlue" Height="20" CornerRadius="4">
+                        <Border.Width>
+                            <MultiBinding Converter="{StaticResource BarWidthConverter}">
+                                <Binding Path="Value"/>
+                                <Binding RelativeSource="{RelativeSource AncestorType=UserControl}" Path="Tag"/>
+                            </MultiBinding>
+                        </Border.Width>
+                    </Border>
+                    <TextBlock Text="{Binding Value}" Margin="5,0,0,0"/>
+                </StackPanel>
+            </DataTemplate>
+        </ItemsControl.ItemTemplate>
+    </ItemsControl>
+</UserControl>

--- a/Controls/HorizontalBarChartControl.xaml.cs
+++ b/Controls/HorizontalBarChartControl.xaml.cs
@@ -1,0 +1,60 @@
+using System.Collections;
+using System.ComponentModel;
+using System.Windows.Controls;
+
+namespace ManutMap.Controls
+{
+    public partial class HorizontalBarChartControl : UserControl, INotifyPropertyChanged
+    {
+        public HorizontalBarChartControl()
+        {
+            InitializeComponent();
+            DataContext = this;
+        }
+
+        private IEnumerable? _items;
+        public IEnumerable? Items
+        {
+            get => _items;
+            set
+            {
+                _items = value;
+                OnPropertyChanged(nameof(Items));
+                UpdateMax();
+            }
+        }
+
+        private double _maxValue;
+        public double MaxValue
+        {
+            get => _maxValue;
+            private set
+            {
+                _maxValue = value;
+                OnPropertyChanged(nameof(MaxValue));
+                this.Tag = _maxValue;
+            }
+        }
+
+        private void UpdateMax()
+        {
+            if (_items == null) { MaxValue = 0; return; }
+            double max = 0;
+            foreach (var item in _items)
+            {
+                var prop = item?.GetType().GetProperty("Value");
+                if (prop != null)
+                {
+                    var valObj = prop.GetValue(item);
+                    if (double.TryParse(valObj?.ToString(), out double v) && v > max)
+                        max = v;
+                }
+            }
+            MaxValue = max;
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void OnPropertyChanged(string name)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}

--- a/Helpers/ProportionalWidthConverter.cs
+++ b/Helpers/ProportionalWidthConverter.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace ManutMap.Helpers
+{
+    public class ProportionalWidthConverter : IMultiValueConverter
+    {
+        public double MaxWidth { get; set; } = 200;
+
+        public object Convert(object[] values, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (values.Length < 2) return 0.0;
+            if (!double.TryParse(values[0]?.ToString(), out double val)) return 0.0;
+            if (!double.TryParse(values[1]?.ToString(), out double max)) return 0.0;
+            if (max <= 0) return 0.0;
+            return val / max * MaxWidth;
+        }
+
+        public object[] ConvertBack(object value, Type[] targetTypes, object? parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -527,20 +527,38 @@
             <TabItem Header="Estatísticas">
                 <ScrollViewer>
                     <StackPanel Margin="15" x:Name="StatsPanel">
-                        <TextBlock Text="Coletas de Datalog por Rota" FontWeight="Bold" FontSize="16" Margin="0,0,0,10"/>
-                        <controls:BarChartControl x:Name="RouteChart" Margin="0,0,0,15" />
+                        <TextBlock x:Name="DatalogSummaryText" FontWeight="Bold" FontSize="14" Margin="0,0,0,15"/>
 
-                        <TextBlock Text="Datalog por Tipo de Serviço" FontWeight="Bold" FontSize="16" Margin="0,10,0,10"/>
-                        <controls:BarChartControl x:Name="TipoServicoChart" Margin="0,0,0,15" />
+                        <Border Style="{StaticResource Card}">
+                            <StackPanel>
+                                <TextBlock Text="Coletas de Datalog por Rota" FontWeight="Bold" FontSize="16" Margin="0,0,0,10"/>
+                                <controls:HorizontalBarChartControl x:Name="RouteChart" />
+                            </StackPanel>
+                        </Border>
 
-                        <TextBlock Text="Ordens de Serviço sem Datalog" FontWeight="Bold" FontSize="16" Margin="0,10,0,5"/>
-                        <DataGrid x:Name="DatalogMissingGrid" AutoGenerateColumns="False" Height="200">
-                            <DataGrid.Columns>
-                                <DataGridTextColumn Header="OS" Binding="{Binding NumOS}" Width="*"/>
-                                <DataGridTextColumn Header="IDSIGFI" Binding="{Binding IdSigfi}" Width="*"/>
-                                <DataGridTextColumn Header="ROTA" Binding="{Binding Rota}" Width="*"/>
-                            </DataGrid.Columns>
-                        </DataGrid>
+                        <Border Style="{StaticResource Card}">
+                            <StackPanel>
+                                <TextBlock Text="Datalog por Tipo de Serviço" FontWeight="Bold" FontSize="16" Margin="0,0,0,10"/>
+                                <controls:HorizontalBarChartControl x:Name="TipoServicoChart" />
+                            </StackPanel>
+                        </Border>
+
+                        <Border Style="{StaticResource Card}">
+                            <StackPanel>
+                                <TextBlock FontWeight="Bold" FontSize="16" Margin="0,0,0,5">
+                                    <Run Text="Ordens de Serviço sem Datalog ("/>
+                                    <Run x:Name="MissingCountText"/>
+                                    <Run Text=")"/>
+                                </TextBlock>
+                                <DataGrid x:Name="DatalogMissingGrid" AutoGenerateColumns="False" Height="200">
+                                    <DataGrid.Columns>
+                                        <DataGridTextColumn Header="OS" Binding="{Binding NumOS}" Width="*"/>
+                                        <DataGridTextColumn Header="IDSIGFI" Binding="{Binding IdSigfi}" Width="*"/>
+                                        <DataGridTextColumn Header="ROTA" Binding="{Binding Rota}" Width="*"/>
+                                    </DataGrid.Columns>
+                                </DataGrid>
+                            </StackPanel>
+                        </Border>
                     </StackPanel>
                 </ScrollViewer>
             </TabItem>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -382,13 +382,19 @@ namespace ManutMap
 
             int datalogCount = dadosFiltrados.Count(item =>
                 item["TEMDATALOG"]?.ToObject<bool>() == true);
+            int totalCount = dadosFiltrados.Count();
+            int missingCount = totalCount - datalogCount;
+            double rate = totalCount > 0 ? datalogCount * 100.0 / totalCount : 0.0;
 
             // Atualiza cada TextBlock individualmente
             PreventivasStatsText.Text = $"{prevAbertas} abertas, {prevConcluidas} concluídas";
             CorretivasStatsText.Text = $"{corrAbertas} abertas, {corrConcluidas} concluídas";
             ServicosStatsText.Text = $"{servAbertos} abertos, {servConcluidos} concluídos";
             DatalogStatsText.Text = datalogCount.ToString();
-            TotalStatsText.Text = dadosFiltrados.Count().ToString();
+            TotalStatsText.Text = totalCount.ToString();
+
+            DatalogSummaryText.Text = $"{datalogCount} OS com Datalog (" + rate.ToString("0.#") + "%)";
+            MissingCountText.Text = missingCount.ToString();
         }
 
         private void AnnotateDatalogInfo()


### PR DESCRIPTION
## Summary
- design horizontal bar chart control and width converter
- use new bar chart control in stats tab wrapped in cards
- show summary text and datalog missing count

## Testing
- `dotnet build -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aef8935c0833392e96d0e264fcb14