### PR TITLE
Fix duplicate variable declarations in map helper

### DIFF
--- a/Helpers/MapHtmlHelper.cs
+++ b/Helpers/MapHtmlHelper.cs
@@ -102,14 +102,6 @@ namespace ManutMap.Helpers
         var prevProx = item.PREV_PROXIMA ? fmtDate(item.PREV_PROXIMA) : '';
         var prevDias = item.PREV_DIAS;
         var corrDias = item.CORR_DIAS;
-        var prevUlt = item.PREV_ULTIMA ? fmtDate(item.PREV_ULTIMA) : '';
-        var prevProx = item.PREV_PROXIMA ? fmtDate(item.PREV_PROXIMA) : '';
-        var prevDias = item.PREV_DIAS;
-        var corrDias = item.CORR_DIAS;
-        var prevUlt = item.PREV_ULTIMA ? fmtDate(item.PREV_ULTIMA) : '';
-        var prevProx = item.PREV_PROXIMA ? fmtDate(item.PREV_PROXIMA) : '';
-        var prevDias = item.PREV_DIAS;
-        var corrDias = item.CORR_DIAS;
 
         var popup = '<b>OS:</b> '+item.NUMOS+'<br>'+
                     '<b>Cliente:</b> '+item.NOMECLIENTE+'<br>'+


### PR DESCRIPTION
## Summary
- remove redundant variable declarations inside `MapHtmlHelper.GetHtml`

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af1bd991c8333a2f32abfb9f00d05