### PR TITLE
Fix statistics filtering and chart updates

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -352,6 +352,7 @@ namespace ManutMap
             }
 
             AtualizarPainelEstatisticas(filteredResult);
+            UpdateStatsTab(filteredResult);
         }
 
         // MÉTODO DE ESTATÍSTICAS ATUALIZADO para a nova barra
@@ -639,11 +640,11 @@ namespace ManutMap
             win.Show();
         }
 
-        private void UpdateStatsTab()
+        private void UpdateStatsTab(IEnumerable<JObject>? source = null)
         {
-            if (_manutList == null) return;
+            if (source == null && _manutList == null) return;
 
-            var all = _manutList.OfType<JObject>().ToList();
+            var all = source?.ToList() ?? _manutList!.OfType<JObject>().ToList();
             var withDatalog = all.Where(o => o["TEMDATALOG"]?.ToObject<bool>() == true).ToList();
             var withoutDatalog = all.Where(o => o["TEMDATALOG"]?.ToObject<bool>() != true).ToList();
 


### PR DESCRIPTION
## Summary
- apply current filters to statistics
- update statistics tab with filtered data so charts show values

## Testing
- `dotnet build -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af872e23483339bfe39dde978682f