### PR TITLE
Update datalog route chart to line style

### DIFF
--- a/Controls/LineChartControl.xaml
+++ b/Controls/LineChartControl.xaml
@@ -1,0 +1,23 @@
+<UserControl x:Class="ManutMap.Controls.LineChartControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <Canvas x:Name="ChartCanvas" Grid.Row="0" Height="150" />
+        <ItemsControl x:Name="LabelHost" Grid.Row="1" ItemsSource="{Binding Labels}">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <UniformGrid Rows="1" />
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding}" Margin="2" HorizontalAlignment="Center" />
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
+    </Grid>
+</UserControl>

--- a/Controls/LineChartControl.xaml.cs
+++ b/Controls/LineChartControl.xaml.cs
@@ -1,0 +1,139 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Shapes;
+
+namespace ManutMap.Controls
+{
+    public partial class LineChartControl : UserControl, INotifyPropertyChanged
+    {
+        public LineChartControl()
+        {
+            InitializeComponent();
+            DataContext = this;
+            Loaded += (_, _) => DrawChart();
+            SizeChanged += (_, _) => DrawChart();
+        }
+
+        private IEnumerable? _items;
+        public IEnumerable? Items
+        {
+            get => _items;
+            set
+            {
+                _items = value;
+                OnPropertyChanged(nameof(Items));
+                UpdateMax();
+                UpdateLabels();
+                DrawChart();
+            }
+        }
+
+        private double _maxValue;
+        public double MaxValue
+        {
+            get => _maxValue;
+            private set
+            {
+                _maxValue = value;
+                OnPropertyChanged(nameof(MaxValue));
+                this.Tag = _maxValue;
+            }
+        }
+
+        private List<string> _labels = new();
+        public List<string> Labels
+        {
+            get => _labels;
+            private set
+            {
+                _labels = value;
+                OnPropertyChanged(nameof(Labels));
+            }
+        }
+
+        private void UpdateLabels()
+        {
+            var list = new List<string>();
+            if (_items != null)
+            {
+                foreach (var item in _items)
+                {
+                    if (item == null) continue;
+                    var type = item.GetType();
+                    var prop = type.GetProperty("Label") ?? type.GetProperty("Route");
+                    list.Add(prop?.GetValue(item)?.ToString() ?? string.Empty);
+                }
+            }
+            Labels = list;
+        }
+
+        private void UpdateMax()
+        {
+            if (_items == null) { MaxValue = 0; return; }
+            double max = 0;
+            foreach (var item in _items)
+            {
+                if (item == null) continue;
+                var type = item.GetType();
+                var prop = type.GetProperty("Value") ?? type.GetProperty("Count");
+                if (prop != null && double.TryParse(prop.GetValue(item)?.ToString(), out double v) && v > max)
+                    max = v;
+            }
+            MaxValue = max;
+        }
+
+        private void DrawChart()
+        {
+            ChartCanvas.Children.Clear();
+            if (_items == null || MaxValue <= 0) return;
+            var list = _items.Cast<object>().ToList();
+            int n = list.Count;
+            if (n == 0) return;
+
+            double width = ChartCanvas.ActualWidth;
+            double height = ChartCanvas.ActualHeight;
+            if (width == 0 || height == 0) return;
+
+            var poly = new Polyline
+            {
+                Stroke = Brushes.SteelBlue,
+                StrokeThickness = 2
+            };
+
+            for (int i = 0; i < n; i++)
+            {
+                var item = list[i];
+                var prop = item.GetType().GetProperty("Value") ?? item.GetType().GetProperty("Count");
+                double val = 0;
+                if (prop != null)
+                    double.TryParse(prop.GetValue(item)?.ToString(), out val);
+
+                double x = n == 1 ? width / 2 : i * width / (n - 1);
+                double y = height - (val / MaxValue * height);
+                poly.Points.Add(new System.Windows.Point(x, y));
+
+                var ell = new Ellipse
+                {
+                    Width = 8,
+                    Height = 8,
+                    Fill = Brushes.SteelBlue,
+                    Stroke = Brushes.White,
+                    StrokeThickness = 2
+                };
+                Canvas.SetLeft(ell, x - 4);
+                Canvas.SetTop(ell, y - 4);
+                ChartCanvas.Children.Add(ell);
+            }
+
+            ChartCanvas.Children.Insert(0, poly);
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+        private void OnPropertyChanged(string name)
+            => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -532,7 +532,7 @@
                             <StackPanel>
                                 <TextBlock Text="Coletas de Datalog por Rota" FontWeight="Bold" FontSize="16" Margin="0,0,0,4"/>
                                 <TextBlock Text="Mostra a quantidade de coletas em cada rota." TextWrapping="Wrap" Foreground="{StaticResource Text.Secondary}" FontSize="12" Margin="0,0,0,10"/>
-                                <controls:HorizontalBarChartControl x:Name="RouteChart" />
+                                <controls:LineChartControl x:Name="RouteChart" Height="200" />
                             </StackPanel>
                         </Border>
 


### PR DESCRIPTION
## Summary
- add new `LineChartControl` user control to draw line charts
- switch stats view from horizontal bar chart to the new line chart

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b09aaeecc833387b1e2294e0af338