### PR TITLE
Add datalog completion alerts

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -553,17 +553,36 @@
                                     <Run Text=")"/>
                                 </TextBlock>
                                 <TextBlock Text="Lista as ordens que ainda não possuem coletas de datalog." TextWrapping="Wrap" Foreground="{StaticResource Text.Secondary}" FontSize="12" Margin="0,0,0,10"/>
-                                <DataGrid x:Name="DatalogMissingGrid" AutoGenerateColumns="False" Height="200">
-                                    <DataGrid.Columns>
-                                        <DataGridTextColumn Header="OS" Binding="{Binding NumOS}" Width="*"/>
-                                        <DataGridTextColumn Header="IDSIGFI" Binding="{Binding IdSigfi}" Width="*"/>
-                                        <DataGridTextColumn Header="ROTA" Binding="{Binding Rota}" Width="*"/>
-                                    </DataGrid.Columns>
-                                </DataGrid>
-                            </StackPanel>
-                        </Border>
+                        <DataGrid x:Name="DatalogMissingGrid" AutoGenerateColumns="False" Height="200">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="OS" Binding="{Binding NumOS}" Width="*"/>
+                                <DataGridTextColumn Header="IDSIGFI" Binding="{Binding IdSigfi}" Width="*"/>
+                                <DataGridTextColumn Header="ROTA" Binding="{Binding Rota}" Width="*"/>
+                            </DataGrid.Columns>
+                        </DataGrid>
                     </StackPanel>
-                </ScrollViewer>
+                </Border>
+
+                <Border Style="{StaticResource Card}">
+                    <StackPanel>
+                        <TextBlock FontWeight="Bold" FontSize="16" Margin="0,0,0,4"
+                                   Text="OS concluídas há mais de 2 dias sem Datalog"/>
+                        <TextBlock Text="Alertas de ordens concluídas há mais de 2 dias que ainda não possuem coletas de datalog." TextWrapping="Wrap" Foreground="{StaticResource Text.Secondary}" FontSize="12" Margin="0,0,0,10"/>
+                        <DataGrid x:Name="DatalogAlertGrid" AutoGenerateColumns="False" Height="200" LoadingRow="DatalogAlertGrid_LoadingRow">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="OS" Binding="{Binding NumOS}" Width="*"/>
+                                <DataGridTextColumn Header="IDSIGFI" Binding="{Binding IdSigfi}" Width="*"/>
+                                <DataGridTextColumn Header="CLIENTE" Binding="{Binding Cliente}" Width="*"/>
+                                <DataGridTextColumn Header="ROTA" Binding="{Binding Rota}" Width="*"/>
+                                <DataGridTextColumn Header="SERVIÇO" Binding="{Binding Tipo}" Width="*"/>
+                                <DataGridTextColumn Header="CONCLUSÃO" Binding="{Binding Conclusao, StringFormat=d}" Width="*"/>
+                                <DataGridTextColumn Header="DIAS" Binding="{Binding DiasSemDatalog}" Width="*"/>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </StackPanel>
+                </Border>
+            </StackPanel>
+        </ScrollViewer>
             </TabItem>
         </TabControl>
     </Grid>

--- a/Models/OsAlertInfo.cs
+++ b/Models/OsAlertInfo.cs
@@ -1,0 +1,13 @@
+namespace ManutMap.Models
+{
+    public class OsAlertInfo
+    {
+        public string NumOS { get; set; } = string.Empty;
+        public string IdSigfi { get; set; } = string.Empty;
+        public string Cliente { get; set; } = string.Empty;
+        public string Rota { get; set; } = string.Empty;
+        public string Tipo { get; set; } = string.Empty;
+        public DateTime Conclusao { get; set; }
+        public int DiasSemDatalog { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- show OS concluded over two days without datalog on a new grid
- add backing model `OsAlertInfo`
- highlight alert rows in red

## Testing
- `dotnet build -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b1096389c83338faa755dfb121671