### PR TITLE
Limit datalog alerts to recent OS

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -574,8 +574,8 @@
                 <Border Style="{StaticResource Card}">
                     <StackPanel>
                         <TextBlock FontWeight="Bold" FontSize="16" Margin="0,0,0,4"
-                                   Text="OS concluídas há mais de 2 dias sem Datalog"/>
-                        <TextBlock Text="Alertas de ordens concluídas há mais de 2 dias que ainda não possuem coletas de datalog." TextWrapping="Wrap" Foreground="{StaticResource Text.Secondary}" FontSize="12" Margin="0,0,0,10"/>
+                                   Text="OS concluídas há mais de 2 dias sem Datalog (últimos 15 dias)"/>
+                        <TextBlock Text="Alertas de ordens concluídas há mais de 2 dias nos últimos 15 dias que ainda não possuem coletas de datalog." TextWrapping="Wrap" Foreground="{StaticResource Text.Secondary}" FontSize="12" Margin="0,0,0,10"/>
                         <DataGrid x:Name="DatalogAlertGrid" AutoGenerateColumns="False" Height="200" LoadingRow="DatalogAlertGrid_LoadingRow">
                             <DataGrid.Columns>
                                 <DataGridTextColumn Header="OS" Binding="{Binding NumOS}" Width="*"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -735,7 +735,7 @@ namespace ManutMap
                     DateTime.TryParse(dtStr, pt, System.Globalization.DateTimeStyles.None, out var dt))
                 {
                     int dias = (int)(DateTime.Today - dt.Date).TotalDays;
-                    if (dias > 2)
+                    if (dias > 2 && dias <= 15)
                     {
                         _osAlertaDatalog.Add(new OsAlertInfo
                         {


### PR DESCRIPTION
## Summary
- show datalog alert text with 15‑day window
- filter alert list to only include OS concluded within last 15 days

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b14fba3188333838f629e163d4300