### PR TITLE
Melhoria no card de O.S sem datalog

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -558,13 +558,15 @@
                         <TextBlock FontWeight="Bold" FontSize="16" Margin="0,0,0,4"
                                    Text="OS concluídas há mais de 2 dias sem Datalog (últimos 15 dias)"/>
                         <TextBlock Text="Alertas de ordens concluídas há mais de 2 dias nos últimos 15 dias que ainda não possuem coletas de datalog." TextWrapping="Wrap" Foreground="{StaticResource Text.Secondary}" FontSize="12" Margin="0,0,0,10"/>
-                        <DataGrid x:Name="DatalogAlertGrid" AutoGenerateColumns="False" Height="200" LoadingRow="DatalogAlertGrid_LoadingRow">
+                        <DataGrid x:Name="DatalogAlertGrid" AutoGenerateColumns="False" Height="200" LoadingRow="DatalogAlertGrid_LoadingRow"
+                                  AlternatingRowBackground="#FAFAFA" RowHeight="34" ColumnHeaderHeight="36" HeadersVisibility="Column" IsReadOnly="True">
+                            <DataGrid.RowStyle>
+                                <Style TargetType="DataGridRow">
+                                    <Setter Property="ToolTip" Value="{Binding Tooltip}"/>
+                                </Style>
+                            </DataGrid.RowStyle>
                             <DataGrid.Columns>
                                 <DataGridTextColumn Header="OS" Binding="{Binding NumOS}" Width="*"/>
-                                <DataGridTextColumn Header="IDSIGFI" Binding="{Binding IdSigfi}" Width="*"/>
-                                <DataGridTextColumn Header="CLIENTE" Binding="{Binding Cliente}" Width="*"/>
-                                <DataGridTextColumn Header="ROTA" Binding="{Binding Rota}" Width="*"/>
-                                <DataGridTextColumn Header="SERVIÇO" Binding="{Binding Tipo}" Width="*"/>
                                 <DataGridTextColumn Header="CONCLUSÃO" Binding="{Binding Conclusao, StringFormat=d}" Width="*"/>
                                 <DataGridTextColumn Header="DIAS" Binding="{Binding DiasSemDatalog}" Width="*"/>
                             </DataGrid.Columns>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -737,6 +737,14 @@ namespace ManutMap
                     int dias = (int)(DateTime.Today - dt.Date).TotalDays;
                     if (dias > 2 && dias <= 15)
                     {
+                        var jobj = (JObject)o;
+                        string tooltip = string.Empty;
+                        if (jobj.TryGetValue("DESCADICIONALEXEC", out var desc))
+                        {
+                            tooltip = $"DESCADICIONALEXEC: {desc}\n";
+                        }
+                        tooltip += string.Join("\n", jobj.Properties()
+                            .Select(p => $"{p.Name}: {p.Value}"));
                         _osAlertaDatalog.Add(new OsAlertInfo
                         {
                             NumOS = (o["NUMOS"]?.ToString() ?? string.Empty).Trim(),
@@ -745,7 +753,9 @@ namespace ManutMap
                             Rota = (o["ROTA"]?.ToString() ?? string.Empty).Trim(),
                             Tipo = (o["TIPO"]?.ToString() ?? string.Empty).Trim(),
                             Conclusao = dt,
-                            DiasSemDatalog = dias
+                            DiasSemDatalog = dias,
+                            Tooltip = tooltip,
+                            Raw = (JObject)o
                         });
                     }
                 }

--- a/Models/OsAlertInfo.cs
+++ b/Models/OsAlertInfo.cs
@@ -1,4 +1,5 @@
 using System;
+using Newtonsoft.Json.Linq;
 
 namespace ManutMap.Models
 {
@@ -11,5 +12,7 @@ namespace ManutMap.Models
         public string Tipo { get; set; } = string.Empty;
         public DateTime Conclusao { get; set; }
         public int DiasSemDatalog { get; set; }
+        public string Tooltip { get; set; } = string.Empty;
+        public JObject? Raw { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- show a cleaner datalog alert grid
- include tooltip with extra JSON info
- expose fields for tooltip in `OsAlertInfo`

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b17a07d94833387757aff2e619648