### PR TITLE
Add details popup for datalog alert list

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -120,6 +120,17 @@
             </Setter>
         </Style>
 
+        <Style x:Key="ModernDataGrid" TargetType="DataGrid">
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Background" Value="White"/>
+            <Setter Property="RowBackground" Value="White"/>
+            <Setter Property="AlternatingRowBackground" Value="#FAFAFA"/>
+            <Setter Property="GridLinesVisibility" Value="None"/>
+            <Setter Property="HeadersVisibility" Value="Column"/>
+            <Setter Property="CanUserAddRows" Value="False"/>
+            <Setter Property="IsReadOnly" Value="True"/>
+        </Style>
+
         <Style TargetType="Expander">
             <Setter Property="Padding" Value="0"/>
             <Setter Property="Template">
@@ -558,8 +569,9 @@
                         <TextBlock FontWeight="Bold" FontSize="16" Margin="0,0,0,4"
                                    Text="OS concluídas há mais de 2 dias sem Datalog (últimos 15 dias)"/>
                         <TextBlock Text="Alertas de ordens concluídas há mais de 2 dias nos últimos 15 dias que ainda não possuem coletas de datalog." TextWrapping="Wrap" Foreground="{StaticResource Text.Secondary}" FontSize="12" Margin="0,0,0,10"/>
-                        <DataGrid x:Name="DatalogAlertGrid" AutoGenerateColumns="False" Height="200" LoadingRow="DatalogAlertGrid_LoadingRow"
-                                  AlternatingRowBackground="#FAFAFA" RowHeight="34" ColumnHeaderHeight="36" HeadersVisibility="Column" IsReadOnly="True">
+                        <DataGrid x:Name="DatalogAlertGrid" AutoGenerateColumns="False" Height="200"
+                                  LoadingRow="DatalogAlertGrid_LoadingRow" MouseDoubleClick="DatalogAlertGrid_RowDoubleClick"
+                                  RowHeight="34" ColumnHeaderHeight="36" Style="{StaticResource ModernDataGrid}">
                             <DataGrid.RowStyle>
                                 <Style TargetType="DataGridRow">
                                     <Setter Property="ToolTip" Value="{Binding Tooltip}"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -776,5 +776,17 @@ namespace ManutMap
             }
         }
 
+        private void DatalogAlertGrid_RowDoubleClick(object sender, MouseButtonEventArgs e)
+        {
+            if (DatalogAlertGrid.SelectedItem is OsAlertInfo info && info.Raw != null)
+            {
+                var win = new OsDetailWindow(info.Raw)
+                {
+                    Owner = this
+                };
+                win.ShowDialog();
+            }
+        }
+
     }
 }

--- a/OsDetailWindow.xaml
+++ b/OsDetailWindow.xaml
@@ -1,0 +1,24 @@
+<Window x:Class="ManutMap.OsDetailWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Detalhes da OS" Height="400" Width="500"
+        WindowStartupLocation="CenterOwner"
+        Background="#F5F5F5">
+    <Grid Margin="15">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="0" Margin="0,0,0,10">
+            <TextBlock x:Name="DescExecText" FontWeight="Bold" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <DataGrid x:Name="DetailsGrid" Grid.Row="1" AutoGenerateColumns="False" IsReadOnly="True" AlternatingRowBackground="#FAFAFA">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Campo" Binding="{Binding Name}" Width="*"/>
+                <DataGridTextColumn Header="Valor" Binding="{Binding Value}" Width="2*"/>
+            </DataGrid.Columns>
+        </DataGrid>
+    </Grid>
+</Window>

--- a/OsDetailWindow.xaml.cs
+++ b/OsDetailWindow.xaml.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using Newtonsoft.Json.Linq;
+
+namespace ManutMap
+{
+    public partial class OsDetailWindow : Window
+    {
+        public OsDetailWindow(JObject data)
+        {
+            InitializeComponent();
+
+            if (data.TryGetValue("DESCADICIONALEXEC", out var desc))
+            {
+                DescExecText.Text = $"DESCADICIONALEXEC: {desc}";
+            }
+            else
+            {
+                DescExecText.Text = "DESCADICIONALEXEC: -";
+            }
+
+            var items = data.Properties()
+                .Select(p => new KeyValuePair<string, string>(p.Name, p.Value.ToString()))
+                .ToList();
+            DetailsGrid.ItemsSource = items;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a modern DataGrid style and apply it to the OS alert card
- show OS details with new `OsDetailWindow` when a row is double-clicked
- highlight `DESCADICIONALEXEC` at the top of the popup

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b1a498c8c83339ed9b91a69e700c8