### PR TITLE
Improve OS alert card and popup

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -131,6 +131,35 @@
             <Setter Property="IsReadOnly" Value="True"/>
         </Style>
 
+        <Style x:Key="OsAlertRowStyle" TargetType="DataGridRow">
+            <Setter Property="Margin" Value="0,0,0,6"/>
+            <Setter Property="Padding" Value="8"/>
+            <Setter Property="Background" Value="{StaticResource Background.Panel}"/>
+            <Setter Property="BorderBrush" Value="{StaticResource Border.Default}"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="ToolTip" Value="{Binding Tooltip}"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="DataGridRow">
+                        <Border x:Name="Bd" BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="4"
+                                Background="{TemplateBinding Background}" Padding="{TemplateBinding Padding}">
+                            <DataGridCellsPresenter/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="{StaticResource Background.Hover}"/>
+                            </Trigger>
+                            <Trigger Property="IsSelected" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="{StaticResource BrandBlue}"/>
+                                <Setter Property="Foreground" Value="White"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
         <Style TargetType="Expander">
             <Setter Property="Padding" Value="0"/>
             <Setter Property="Template">
@@ -573,13 +602,11 @@
                                   LoadingRow="DatalogAlertGrid_LoadingRow" MouseDoubleClick="DatalogAlertGrid_RowDoubleClick"
                                   RowHeight="34" ColumnHeaderHeight="36" Style="{StaticResource ModernDataGrid}">
                             <DataGrid.RowStyle>
-                                <Style TargetType="DataGridRow">
-                                    <Setter Property="ToolTip" Value="{Binding Tooltip}"/>
-                                </Style>
+                                <StaticResource ResourceKey="OsAlertRowStyle"/>
                             </DataGrid.RowStyle>
                             <DataGrid.Columns>
                                 <DataGridTextColumn Header="OS" Binding="{Binding NumOS}" Width="*"/>
-                                <DataGridTextColumn Header="CONCLUSÃO" Binding="{Binding Conclusao, StringFormat=d}" Width="*"/>
+                                <DataGridTextColumn Header="CONCLUSÃO" Binding="{Binding Conclusao, StringFormat='dd/MM/yyyy'}" Width="*"/>
                                 <DataGridTextColumn Header="DIAS" Binding="{Binding DiasSemDatalog}" Width="*"/>
                             </DataGrid.Columns>
                         </DataGrid>

--- a/OsDetailWindow.xaml
+++ b/OsDetailWindow.xaml
@@ -10,15 +10,51 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <StackPanel Grid.Row="0" Margin="0,0,0,10">
-            <TextBlock x:Name="DescExecText" FontWeight="Bold" TextWrapping="Wrap"/>
-        </StackPanel>
+        <TextBlock x:Name="DescExecText" Grid.Row="0" FontWeight="Bold" TextWrapping="Wrap" Margin="0,0,0,10"/>
 
-        <DataGrid x:Name="DetailsGrid" Grid.Row="1" AutoGenerateColumns="False" IsReadOnly="True" AlternatingRowBackground="#FAFAFA">
-            <DataGrid.Columns>
-                <DataGridTextColumn Header="Campo" Binding="{Binding Name}" Width="*"/>
-                <DataGridTextColumn Header="Valor" Binding="{Binding Value}" Width="2*"/>
-            </DataGrid.Columns>
-        </DataGrid>
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto"/>
+                <ColumnDefinition Width="*"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0" Text="Número OS:" FontWeight="Bold"/>
+            <TextBlock Grid.Row="0" Grid.Column="1" x:Name="NumOsText"/>
+
+            <TextBlock Grid.Row="1" Text="IDSIGFI:" FontWeight="Bold"/>
+            <TextBlock Grid.Row="1" Grid.Column="1" x:Name="IdSigfiText"/>
+
+            <TextBlock Grid.Row="2" Text="Rota:" FontWeight="Bold"/>
+            <TextBlock Grid.Row="2" Grid.Column="1" x:Name="RotaText"/>
+
+            <TextBlock Grid.Row="3" Text="Tipo:" FontWeight="Bold"/>
+            <TextBlock Grid.Row="3" Grid.Column="1" x:Name="TipoText"/>
+
+            <TextBlock Grid.Row="4" Text="Tipo SIGFI:" FontWeight="Bold"/>
+            <TextBlock Grid.Row="4" Grid.Column="1" x:Name="TipoSigfiText"/>
+
+            <TextBlock Grid.Row="5" Text="Nome:" FontWeight="Bold"/>
+            <TextBlock Grid.Row="5" Grid.Column="1" x:Name="NomeText"/>
+
+            <TextBlock Grid.Row="6" Text="Reclamante:" FontWeight="Bold"/>
+            <TextBlock Grid.Row="6" Grid.Column="1" x:Name="ReclamanteText"/>
+
+            <TextBlock Grid.Row="7" Text="Abertura:" FontWeight="Bold"/>
+            <TextBlock Grid.Row="7" Grid.Column="1" x:Name="AberturaText"/>
+
+            <TextBlock Grid.Row="8" Text="Conclusão:" FontWeight="Bold"/>
+            <TextBlock Grid.Row="8" Grid.Column="1" x:Name="ConclusaoText"/>
+        </Grid>
     </Grid>
 </Window>

--- a/OsDetailWindow.xaml.cs
+++ b/OsDetailWindow.xaml.cs
@@ -1,5 +1,4 @@
-using System.Collections.Generic;
-using System.Linq;
+using System.Globalization;
 using System.Windows;
 using Newtonsoft.Json.Linq;
 
@@ -11,19 +10,31 @@ namespace ManutMap
         {
             InitializeComponent();
 
-            if (data.TryGetValue("DESCADICIONALEXEC", out var desc))
-            {
-                DescExecText.Text = $"DESCADICIONALEXEC: {desc}";
-            }
-            else
-            {
-                DescExecText.Text = "DESCADICIONALEXEC: -";
-            }
+            var culture = new CultureInfo("pt-BR");
 
-            var items = data.Properties()
-                .Select(p => new KeyValuePair<string, string>(p.Name, p.Value.ToString()))
-                .ToList();
-            DetailsGrid.ItemsSource = items;
+            DescExecText.Text = $"DESCADICIONALEXEC: {data["DESCADICIONALEXEC"]?.ToString() ?? "-"}";
+
+            NumOsText.Text = data["NUMOS"]?.ToString() ?? "-";
+            IdSigfiText.Text = data["IDSIGFI"]?.ToString() ?? "-";
+            RotaText.Text = data["ROTA"]?.ToString() ?? "-";
+            TipoText.Text = data["TIPO"]?.ToString() ?? "-";
+            TipoSigfiText.Text = data["TIPODESIGFI"]?.ToString() ?? "-";
+            NomeText.Text = data["NOMECLIENTE"]?.ToString() ?? "-";
+            ReclamanteText.Text = data["RECLAMANTE"]?.ToString() ?? "-";
+
+            AberturaText.Text = FormatDate(data["DTAHORARECLAMACAO"]?.ToString(), culture);
+            ConclusaoText.Text = FormatDate(data["DTCONCLUSAO"]?.ToString(), culture);
+        }
+
+        private static string FormatDate(string? value, CultureInfo culture)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return "-";
+            if (DateTime.TryParse(value, culture, DateTimeStyles.None, out var dt) ||
+                DateTime.TryParse(value, out dt))
+            {
+                return dt.ToString("dd/MM/yyyy", culture);
+            }
+            return value;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add new `OsAlertRowStyle` for a modern DataGrid look
- display conclusion dates with pt-BR format
- overhaul `OsDetailWindow` to only show key info in a simple grid
- format detail popup dates using pt-BR culture

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b1cfeec2083339cdbad4ff7e528f8