### PR TITLE
Update datalog alert card style

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -110,12 +110,14 @@
 
         <Style x:Key="Card" TargetType="Border">
             <Setter Property="Background" Value="{StaticResource Background.Panel}"/>
-            <Setter Property="CornerRadius" Value="6"/>
-            <Setter Property="Padding" Value="15"/>
-            <Setter Property="Margin" Value="0,0,0,15"/>
+            <Setter Property="CornerRadius" Value="8"/>
+            <Setter Property="Padding" Value="12"/>
+            <Setter Property="Margin" Value="0,0,0,12"/>
+            <Setter Property="BorderBrush" Value="{StaticResource Border.Default}"/>
+            <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="Effect">
                 <Setter.Value>
-                    <DropShadowEffect ShadowDepth="1" Color="#E0E0E0" Opacity="0.8" BlurRadius="5"/>
+                    <DropShadowEffect ShadowDepth="1" Color="#000000" Opacity="0.15" BlurRadius="6"/>
                 </Setter.Value>
             </Setter>
         </Style>
@@ -132,12 +134,17 @@
         </Style>
 
         <Style x:Key="OsAlertRowStyle" TargetType="DataGridRow">
-            <Setter Property="Margin" Value="0,0,0,6"/>
-            <Setter Property="Padding" Value="8"/>
+            <Setter Property="Margin" Value="0,0,0,4"/>
+            <Setter Property="Padding" Value="6"/>
             <Setter Property="Background" Value="{StaticResource Background.Panel}"/>
             <Setter Property="BorderBrush" Value="{StaticResource Border.Default}"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="ToolTip" Value="{Binding Tooltip}"/>
+            <Setter Property="Effect">
+                <Setter.Value>
+                    <DropShadowEffect ShadowDepth="1" BlurRadius="3" Opacity="0.1"/>
+                </Setter.Value>
+            </Setter>
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="DataGridRow">


### PR DESCRIPTION
## Summary
- restyle alert cards in statistics tab
- add subtle row shadow effect

## Testing
- `dotnet build ManutMap.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b2fd1a6e0833389c4e4abd8e7929a