### PR TITLE
Fix OS alert grid hover popup and improve performance

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -145,7 +145,6 @@
             <Setter Property="Background" Value="{StaticResource Background.Panel}"/>
             <Setter Property="BorderBrush" Value="{StaticResource Border.Default}"/>
             <Setter Property="BorderThickness" Value="1"/>
-            <Setter Property="ToolTip" Value="{Binding Tooltip}"/>
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="DataGridRow">
@@ -611,6 +610,10 @@
                                    RowHeight="32" ColumnHeaderHeight="32"
                                    RowHeaderWidth="0"
                                    ColumnHeaderStyle="{StaticResource AlertGridColumnHeader}"
+                                   VirtualizingPanel.IsVirtualizing="True"
+                                   VirtualizingPanel.VirtualizationMode="Recycling"
+                                   EnableRowVirtualization="True"
+                                   EnableColumnVirtualization="True"
                                    Style="{StaticResource ModernDataGrid}">
                             <DataGrid.RowStyle>
                                 <StaticResource ResourceKey="OsAlertRowStyle"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -709,12 +709,6 @@ namespace ManutMap
                         if (dias > 2 && dias <= 15)
                         {
                             var jobj = (JObject)o;
-                            string tooltip = string.Empty;
-                            if (jobj.TryGetValue("DESCADICIONALEXEC", out var desc))
-                            {
-                                tooltip = $"DESCADICIONALEXEC: {desc}\n";
-                            }
-                            tooltip += string.Join("\n", jobj.Properties().Select(p => $"{p.Name}: {p.Value}"));
                             _osAlertaDatalog.Add(new OsAlertInfo
                             {
                                 NumOS = (o["NUMOS"]?.ToString() ?? string.Empty).Trim(),
@@ -724,7 +718,6 @@ namespace ManutMap
                                 Tipo = tipo,
                                 Conclusao = dt,
                                 DiasSemDatalog = dias,
-                                Tooltip = tooltip,
                                 Raw = jobj
                             });
                         }

--- a/Models/OsAlertInfo.cs
+++ b/Models/OsAlertInfo.cs
@@ -12,7 +12,6 @@ namespace ManutMap.Models
         public string Tipo { get; set; } = string.Empty;
         public DateTime Conclusao { get; set; }
         public int DiasSemDatalog { get; set; }
-        public string Tooltip { get; set; } = string.Empty;
         public JObject? Raw { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- remove unused Tooltip field in `OsAlertInfo`
- drop tooltip binding from `OsAlertRowStyle`
- enable virtualization on `DatalogAlertGrid`
- adjust OS alert generation to skip tooltip building

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b34767dfc833395faec2eb742a6e6