### PR TITLE
Display OS electrician names

### DIFF
--- a/OsDetailWindow.xaml
+++ b/OsDetailWindow.xaml
@@ -53,6 +53,7 @@
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
                     <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
 
                 <TextBlock Grid.Row="0" Grid.Column="0" Text="Número OS:" Style="{StaticResource LabelStyle}"/>
@@ -81,6 +82,9 @@
 
                 <TextBlock Grid.Row="8" Grid.Column="0" Text="Conclusão:" Style="{StaticResource LabelStyle}"/>
                 <TextBlock Grid.Row="8" Grid.Column="1" x:Name="ConclusaoText" Style="{StaticResource ValueStyle}"/>
+
+                <TextBlock Grid.Row="9" Grid.Column="0" Text="Funcionários:" Style="{StaticResource LabelStyle}"/>
+                <TextBlock Grid.Row="9" Grid.Column="1" x:Name="FuncionariosText" Style="{StaticResource ValueStyle}"/>
             </Grid>
         </StackPanel>
     </Border>

--- a/OsDetailWindow.xaml.cs
+++ b/OsDetailWindow.xaml.cs
@@ -2,18 +2,29 @@ using System.Globalization;
 using System.Windows;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using ManutMap.Services;
 
 namespace ManutMap
 {
     public partial class OsDetailWindow : Window
     {
+        private readonly SharePointService _spService = new SharePointService();
+        private readonly List<string> _matriculas = new();
+
         public OsDetailWindow(JObject data)
         {
             InitializeComponent();
 
+            Loaded += OsDetailWindow_Loaded;
+
             var culture = new CultureInfo("pt-BR");
 
-            DescExecText.Text = $"DESCADICIONALEXEC: {data["DESCADICIONALEXEC"]?.ToString() ?? "-"}";
+            var descExec = data["DESCADICIONALEXEC"]?.ToString() ?? string.Empty;
+            DescExecText.Text = $"DESCADICIONALEXEC: {descExec}";
+
+            ExtractMatriculas(descExec);
 
             NumOsText.Text = data["NUMOS"]?.ToString() ?? "-";
             IdSigfiText.Text = data["IDSIGFI"]?.ToString() ?? "-";
@@ -25,6 +36,8 @@ namespace ManutMap
 
             AberturaText.Text = FormatDate(data["DTAHORARECLAMACAO"]?.ToString(), culture);
             ConclusaoText.Text = FormatDate(data["DTCONCLUSAO"]?.ToString(), culture);
+
+            FuncionariosText.Text = string.Empty;
         }
 
         private static string FormatDate(string? value, CultureInfo culture)
@@ -36,6 +49,37 @@ namespace ManutMap
                 return dt.ToString("dd/MM/yyyy", culture);
             }
             return value;
+        }
+
+        private void ExtractMatriculas(string text)
+        {
+            if (string.IsNullOrWhiteSpace(text)) return;
+            foreach (Match m in Regex.Matches(text, "#(\\d+)"))
+            {
+                var val = m.Groups[1].Value.TrimStart('0');
+                if (!string.IsNullOrWhiteSpace(val) && !_matriculas.Contains(val))
+                    _matriculas.Add(val);
+            }
+        }
+
+        private async void OsDetailWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            FuncionariosText.Text = "Carregando...";
+            try
+            {
+                var mapa = await _spService.DownloadFuncionariosAsync();
+                var nomes = new List<string>();
+                foreach (var mat in _matriculas)
+                {
+                    if (mapa.TryGetValue(mat, out var nome))
+                        nomes.Add(nome);
+                }
+                FuncionariosText.Text = nomes.Count > 0 ? string.Join(", ", nomes) : "-";
+            }
+            catch
+            {
+                FuncionariosText.Text = "Erro ao carregar";
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a new row in `OsDetailWindow` to show electricians
- parse registration numbers in `DESCADICIONALEXEC` and fetch names from `funcionarios.csv`

## Testing
- `dotnet build -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b37ba4d9c8333a54a960d1c6a23f4