### PR TITLE
Add route column and adjust alert grid spacing

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -614,12 +614,14 @@
                                    VirtualizingPanel.VirtualizationMode="Recycling"
                                    EnableRowVirtualization="True"
                                    EnableColumnVirtualization="True"
+                                   ColumnWidth="Auto"
                                    Style="{StaticResource ModernDataGrid}">
                             <DataGrid.RowStyle>
                                 <StaticResource ResourceKey="OsAlertRowStyle"/>
                             </DataGrid.RowStyle>
                             <DataGrid.Columns>
                                 <DataGridTextColumn Header="OS" Binding="{Binding NumOS}" Width="*"/>
+                                <DataGridTextColumn Header="ROTA" Binding="{Binding Rota}" Width="*"/>
                                 <DataGridTextColumn Header="CONCLUSÃO" Binding="{Binding Conclusao, StringFormat='dd/MM/yyyy'}" Width="*"/>
                                 <DataGridTextColumn Header="DIAS" Binding="{Binding DiasSemDatalog}" Width="*"/>
                             </DataGrid.Columns>


### PR DESCRIPTION
## Summary
- show the route in the alert grid of OS concluídas
- reduce column spacing via `ColumnWidth="Auto"`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bbfa2971c8333ab956cb87afd3dd7