### PR TITLE
Optimize statistics tab

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -522,7 +522,7 @@
             </DockPanel>
         </Border>
         
-        <TabControl Grid.Column="2">
+        <TabControl x:Name="MainTabControl" Grid.Column="2" SelectionChanged="MainTabControl_SelectionChanged">
             <TabItem Header="Mapa">
                 <Grid>
                     <Grid.RowDefinitions>


### PR DESCRIPTION
## Summary
- defer statistics refresh until the tab is opened
- keep filtered data cached
- load stats asynchronously for smoother rendering

## Testing
- `dotnet build -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bcb65b7908333b44222f7eab11fcb