### PR TITLE
Fix drive lookup error

### DIFF
--- a/Services/DatalogService.cs
+++ b/Services/DatalogService.cs
@@ -262,7 +262,12 @@ namespace ManutMap.Services
         private async Task<string> GetDriveId(string siteId, string driveName)
         {
             var drives = await _graph.Sites[siteId].Drives.GetAsync();
-            return drives.Value.First(d => d.Name == driveName).Id!;
+            var drive = drives.Value.FirstOrDefault(d => d.Name.Equals(driveName,
+                StringComparison.OrdinalIgnoreCase));
+            if (drive == null)
+                throw new InvalidOperationException($"Drive '{driveName}' n\u00e3o encontrado.");
+
+            return drive.Id!;
         }
 
         private async Task<List<DriveItem>> GetAllRootFoldersAsync(string driveId,


### PR DESCRIPTION
## Summary
- avoid `InvalidOperationException` when drive name is not found
- throw an informative exception if no drive matches

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686c01d755f4833387d6426fb5830238