### PR TITLE
Improve datalog sync progress reporting

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -250,8 +250,12 @@ namespace ManutMap
             progress?.Report((10, "Baixando dados..."));
             _manutList = await _spService.DownloadLatestJsonAsync();
 
-            progress?.Report((40, "Sincronizando datalog..."));
-            _datalogMap = await _datalogService.GetAllDatalogFoldersAsync();
+            var subProgress = new Progress<(int Percent, string Message)>(p =>
+            {
+                int percent = 40 + p.Percent * 30 / 100;
+                progress?.Report((percent, $"Sincronizando datalog... {p.Message}"));
+            });
+            _datalogMap = await _datalogService.GetAllDatalogFoldersAsync(subProgress);
             AnnotateDatalogInfo();
             AnnotatePrazoInfo();
             await AnnotateFuncionariosInfoAsync();


### PR DESCRIPTION
## Summary
- run datalog folder searches concurrently
- expose progress for datalog service
- map service progress into main sync progress

## Testing
- `dotnet build -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c16fef1108333b39fe010963729d4