### PR TITLE
Fix prazo filter when items lack deadline info

### DIFF
--- a/Services/FilterService.cs
+++ b/Services/FilterService.cs
@@ -92,15 +92,17 @@ namespace ManutMap.Services
                         if (item["CORR_DIAS"] != null && int.TryParse(item["CORR_DIAS"].ToString(), out var corr))
                         {
                             has = true;
-                            ok |= CheckPrazo(corr, c);
+                            if (CheckPrazo(corr, c))
+                                ok = true;
                         }
                         if (item["PREV_DIAS"] != null && int.TryParse(item["PREV_DIAS"].ToString(), out var prev))
                         {
                             has = true;
-                            ok |= CheckPrazo(prev, c);
+                            if (CheckPrazo(prev, c))
+                                ok = true;
                         }
 
-                        if (!has || !ok)
+                        if (has && !ok)
                             return false;
                     }
 


### PR DESCRIPTION
## Summary
- ensure prazo filter doesn't remove items without prazo fields

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c2055266c8333b6481090477e5f59