### PR TITLE
Improve statistics alert filtering

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -607,6 +607,15 @@
                         <TextBlock FontWeight="Bold" FontSize="16" Margin="0,0,0,4"
                                    Text="OS concluídas há mais de 2 dias sem Datalog (últimos 15 dias)"/>
                         <TextBlock Text="Alertas de ordens concluídas há mais de 2 dias nos últimos 15 dias que ainda não possuem coletas de datalog." TextWrapping="Wrap" Foreground="{StaticResource Text.Secondary}" FontSize="12" Margin="0,0,0,10"/>
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                            <ComboBox x:Name="AlertFieldCombo" Width="120" SelectedIndex="0" SelectionChanged="AlertFieldCombo_SelectionChanged">
+                                <ComboBoxItem>OS</ComboBoxItem>
+                                <ComboBoxItem>ID SIGFI</ComboBoxItem>
+                                <ComboBoxItem>Cliente</ComboBoxItem>
+                                <ComboBoxItem>Rota</ComboBoxItem>
+                            </ComboBox>
+                            <TextBox x:Name="AlertSearchBox" Width="150" Margin="10,0,0,0" TextChanged="AlertSearchBox_TextChanged"/>
+                        </StackPanel>
                         <DataGrid x:Name="DatalogAlertGrid" AutoGenerateColumns="False"
                                    MouseDoubleClick="DatalogAlertGrid_RowDoubleClick"
                                    RowHeight="32" ColumnHeaderHeight="32"

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -798,6 +798,7 @@ namespace ManutMap
 
             DatalogAlertGrid.ItemsSource = null;
             DatalogAlertGrid.ItemsSource = _osAlertaDatalog;
+            FilterAlertGrid();
             RecentRouteChart.Tag = MaxRecentRouteCount;
             RecentRouteChart.Items = _recentRouteStats;
 
@@ -852,6 +853,40 @@ namespace ManutMap
                 };
                 win.ShowDialog();
             }
+        }
+
+        private void AlertSearchBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            FilterAlertGrid();
+        }
+
+        private void AlertFieldCombo_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            FilterAlertGrid();
+        }
+
+        private void FilterAlertGrid()
+        {
+            if (_osAlertaDatalog == null) return;
+
+            var text = AlertSearchBox?.Text?.Trim() ?? string.Empty;
+            int field = AlertFieldCombo?.SelectedIndex ?? 0;
+
+            IEnumerable<OsAlertInfo> list = _osAlertaDatalog;
+
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                list = field switch
+                {
+                    0 => list.Where(o => o.NumOS != null && o.NumOS.IndexOf(text, StringComparison.OrdinalIgnoreCase) >= 0),
+                    1 => list.Where(o => o.IdSigfi != null && o.IdSigfi.IndexOf(text, StringComparison.OrdinalIgnoreCase) >= 0),
+                    2 => list.Where(o => o.Cliente != null && o.Cliente.IndexOf(text, StringComparison.OrdinalIgnoreCase) >= 0),
+                    3 => list.Where(o => o.Rota != null && o.Rota.IndexOf(text, StringComparison.OrdinalIgnoreCase) >= 0),
+                    _ => list
+                };
+            }
+
+            DatalogAlertGrid.ItemsSource = list.ToList();
         }
 
         private async Task AnnotateFuncionariosInfoAsync()


### PR DESCRIPTION
## Summary
- add filter controls to the statistics alert grid
- implement alert filtering logic in code behind

## Testing
- `dotnet build -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c33f4aad88333a5c9cff3d3ffd9d6