### PR TITLE
Show datalog folder visit count

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -577,6 +577,7 @@
                                          Margin="0,5,0,0"/>
 
                             <TextBlock x:Name="SyncProgressText" FontStyle="Italic" Visibility="Collapsed" Margin="0,5,0,0"/>
+                            <TextBlock x:Name="FolderProgressText" FontStyle="Italic" Visibility="Collapsed" Margin="0,2,0,0"/>
                         </StackPanel>
                     </Border>
                 </Grid>


### PR DESCRIPTION
## Summary
- add folder progress text block
- track folders visited during sync
- update DatalogService to report folder visit progress

## Testing
- `dotnet build ManutMap.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d10e2fe6883339face6cf44870671