### PR TITLE
Add overload for GetAllDatalogFoldersAsync

### DIFF
--- a/Services/DatalogService.cs
+++ b/Services/DatalogService.cs
@@ -507,6 +507,13 @@ namespace ManutMap.Services
             return _folderCache!;
         }
 
+        public Task<Dictionary<string, string>> GetAllDatalogFoldersAsync(IProgress<(int Percent, string Message)> progress,
+                                                                         IProgress<int> folderProgress)
+        {
+            return GetAllDatalogFoldersAsync((IProgress<(int Percent, string Message)>?)progress,
+                                             (IProgress<int>?)folderProgress);
+        }
+
         public async Task<Dictionary<string, string>> GetDatalogFoldersPeriodAsync(DateTime ini, DateTime fim)
         {
             var site = await _graph.Sites[$"{Domain}:/sites/{SitePath}"].GetAsync();


### PR DESCRIPTION
## Summary
- add missing overload for `GetAllDatalogFoldersAsync`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d13bdd3b48333b824858ec26afa28