### PR TITLE
Add filter for preventive count per route

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -341,6 +341,7 @@
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
 
                                     <StackPanel Grid.Row="1" Margin="0,0,0,10">
@@ -371,6 +372,18 @@
                                     <StackPanel Grid.Row="5" Margin="0,0,0,10">
                                         <TextBlock Text="Tipo SIGFI" Style="{StaticResource LabelStyle}"/>
                                         <ComboBox x:Name="SigfiFilterCombo" SelectionChanged="FiltersChanged"/>
+                                    </StackPanel>
+
+                                    <StackPanel Grid.Row="6" Margin="0,0,0,10">
+                                        <TextBlock Text="Preventivas na Rota" Style="{StaticResource LabelStyle}"/>
+                                        <ComboBox x:Name="PrevCountRotaCombo" SelectionChanged="FiltersChanged" SelectedIndex="0">
+                                            <ComboBoxItem Content="Todas"/>
+                                            <ComboBoxItem Content="1"/>
+                                            <ComboBoxItem Content="2"/>
+                                            <ComboBoxItem Content="3"/>
+                                            <ComboBoxItem Content="4"/>
+                                            <ComboBoxItem Content="5"/>
+                                        </ComboBox>
                                     </StackPanel>
 
                                 </Grid>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -138,6 +138,7 @@ namespace ManutMap
             PrazoDiasTextBox.TextChanged += FiltersChanged;
             PrazoDiasTextBox.PreviewTextInput += PrazoDiasTextBox_PreviewTextInput;
             TipoPrazoCombo.SelectionChanged += FiltersChanged;
+            PrevCountRotaCombo.SelectionChanged += FiltersChanged;
         }
 
         private void LoadLocalAndPopulate()
@@ -317,6 +318,7 @@ namespace ManutMap
                 IdSigfi = IdSigfiFilterBox.Text.Trim(),
                 Regional = (RegionalFilterCombo.SelectedItem as ComboBoxItem)?.Content.ToString() ?? "Todos",
                 Rota = (RotaFilterCombo.SelectedItem as ComboBoxItem)?.Content.ToString() ?? "Todos",
+                PreventivasPorRota = int.TryParse((PrevCountRotaCombo.SelectedItem as ComboBoxItem)?.Content.ToString(), out var pc) ? pc : 0,
                 StartDate = StartDatePicker.SelectedDate,
                 EndDate = EndDatePicker.SelectedDate,
                 ShowOpen = ChbOpen.IsChecked == true,
@@ -728,6 +730,7 @@ namespace ManutMap
 
             PrazoDiasTextBox.Text = string.Empty;
             TipoPrazoCombo.SelectedIndex = 0;
+            PrevCountRotaCombo.SelectedIndex = 0;
 
             ApplyFilters();
         }

--- a/Models/FilterCriteria.cs
+++ b/Models/FilterCriteria.cs
@@ -11,6 +11,9 @@ namespace ManutMap.Models
         public string Rota { get; set; } = "Todos";
         public string TipoServico { get; set; } = "Todos";
 
+        // Quantidade de preventivas por rota (0 = todas)
+        public int PreventivasPorRota { get; set; }
+
         public DateTime? StartDate { get; set; }
         public DateTime? EndDate { get; set; }
 

--- a/Services/FilterService.cs
+++ b/Services/FilterService.cs
@@ -113,11 +113,29 @@ namespace ManutMap.Services
                 })
                 .ToList();
 
-            return filtered
+            filtered = filtered
                 .GroupBy(o => (o["NUMOS"]?.ToString() ?? string.Empty).Trim(),
                          StringComparer.OrdinalIgnoreCase)
                 .Select(g => g.First())
                 .ToList();
+
+            if (c.PreventivasPorRota > 0)
+            {
+                var counts = filtered
+                    .Where(o => string.Equals(o["TIPO"]?.ToString()?.Trim(), "PREVENTIVA", StringComparison.OrdinalIgnoreCase))
+                    .GroupBy(o => (o["ROTA"]?.ToString() ?? string.Empty).Trim(), StringComparer.OrdinalIgnoreCase)
+                    .ToDictionary(g => g.Key, g => g.Count(), StringComparer.OrdinalIgnoreCase);
+
+                filtered = filtered
+                    .Where(o =>
+                    {
+                        var rota = (o["ROTA"]?.ToString() ?? string.Empty).Trim();
+                        return counts.TryGetValue(rota, out var cnt) && cnt == c.PreventivasPorRota;
+                    })
+                    .ToList();
+            }
+
+            return filtered;
         }
 
         private static bool CheckPrazo(int dias, FilterCriteria c)


### PR DESCRIPTION
## Summary
- extend FilterCriteria with `PreventivasPorRota`
- support new field in `FilterService` and only keep routes with selected preventive count
- add ComboBox in filters UI to choose number of preventives by route
- wire up events and reset logic for new filter

## Testing
- `dotnet build --no-restore -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d302682808333ab3b62a00ad698ed