### PR TITLE
Add route preventive count filter

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -341,6 +341,7 @@
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
 
                                     <StackPanel Grid.Row="1" Margin="0,0,0,10">
@@ -371,6 +372,18 @@
                                     <StackPanel Grid.Row="5" Margin="0,0,0,10">
                                         <TextBlock Text="Tipo SIGFI" Style="{StaticResource LabelStyle}"/>
                                         <ComboBox x:Name="SigfiFilterCombo" SelectionChanged="FiltersChanged"/>
+                                    </StackPanel>
+
+                                    <StackPanel Grid.Row="6" Margin="0,0,0,10">
+                                        <TextBlock Text="Preventivas por Rota" Style="{StaticResource LabelStyle}"/>
+                                        <ComboBox x:Name="PrevCountCombo" SelectionChanged="FiltersChanged" Width="120">
+                                            <ComboBoxItem Content="Todas" IsSelected="True"/>
+                                            <ComboBoxItem Content="1"/>
+                                            <ComboBoxItem Content="2"/>
+                                            <ComboBoxItem Content="3"/>
+                                            <ComboBoxItem Content="4"/>
+                                            <ComboBoxItem Content="5"/>
+                                        </ComboBox>
                                     </StackPanel>
 
                                 </Grid>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -138,6 +138,7 @@ namespace ManutMap
             PrazoDiasTextBox.TextChanged += FiltersChanged;
             PrazoDiasTextBox.PreviewTextInput += PrazoDiasTextBox_PreviewTextInput;
             TipoPrazoCombo.SelectionChanged += FiltersChanged;
+            PrevCountCombo.SelectionChanged += FiltersChanged;
         }
 
         private void LoadLocalAndPopulate()
@@ -334,7 +335,8 @@ namespace ManutMap
                 OnlyDatalog = ChbOnlyDatalog.IsChecked == true,
                 UseClusters = ChbCluster.IsChecked != false,
                 PrazoDias = int.TryParse(PrazoDiasTextBox.Text, out var pd) ? pd : 0,
-                TipoPrazo = (TipoPrazoCombo.SelectedItem as ComboBoxItem)?.Content.ToString() ?? "Todos"
+                TipoPrazo = (TipoPrazoCombo.SelectedItem as ComboBoxItem)?.Content.ToString() ?? "Todos",
+                PrevPorRota = PrevCountCombo.SelectedIndex
             };
         }
 
@@ -728,6 +730,7 @@ namespace ManutMap
 
             PrazoDiasTextBox.Text = string.Empty;
             TipoPrazoCombo.SelectedIndex = 0;
+            PrevCountCombo.SelectedIndex = 0;
 
             ApplyFilters();
         }

--- a/Models/FilterCriteria.cs
+++ b/Models/FilterCriteria.cs
@@ -44,6 +44,10 @@ namespace ManutMap.Models
         // Filtro de prazos
         public int PrazoDias { get; set; }
         public string TipoPrazo { get; set; } = "Todos";
+
+        // Quantidade de preventivas por rota para filtrar
+        // 0 significa todas
+        public int PrevPorRota { get; set; }
     }
 }
 

--- a/Services/FilterService.cs
+++ b/Services/FilterService.cs
@@ -113,6 +113,22 @@ namespace ManutMap.Services
                 })
                 .ToList();
 
+            if (c.PrevPorRota > 0)
+            {
+                var map = filtered
+                    .Where(o => string.Equals(o["TIPO"]?.ToString()?.Trim(), "PREVENTIVA", StringComparison.OrdinalIgnoreCase))
+                    .GroupBy(o => (o["ROTA"]?.ToString() ?? string.Empty).Trim(), StringComparer.OrdinalIgnoreCase)
+                    .ToDictionary(g => g.Key, g => g.Count(), StringComparer.OrdinalIgnoreCase);
+
+                filtered = filtered
+                    .Where(o =>
+                    {
+                        var rota = (o["ROTA"]?.ToString() ?? string.Empty).Trim();
+                        return map.TryGetValue(rota, out var cnt) && cnt == c.PrevPorRota;
+                    })
+                    .ToList();
+            }
+
             return filtered
                 .GroupBy(o => (o["NUMOS"]?.ToString() ?? string.Empty).Trim(),
                          StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
## Summary
- add `PrevPorRota` filter field
- add combo box for selecting routes with 1‑5 preventivas
- hook up new UI element and clear/reset logic
- filter dataset based on number of preventivas per route

## Testing
- `dotnet build -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d302682808333ab3b62a00ad698ed