### PR TITLE
Add filter for completed Preventiva O.S.

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -342,6 +342,7 @@
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
 
                                     <StackPanel Grid.Row="1" Margin="0,0,0,10">
@@ -377,6 +378,18 @@
                                     <StackPanel Grid.Row="6" Margin="0,0,0,10">
                                         <TextBlock Text="Número da Preventiva" Style="{StaticResource LabelStyle}"/>
                                         <ComboBox x:Name="PrevCountRotaCombo" SelectionChanged="FiltersChanged" SelectedIndex="0">
+                                            <ComboBoxItem Content="Todas"/>
+                                            <ComboBoxItem Content="1"/>
+                                            <ComboBoxItem Content="2"/>
+                                            <ComboBoxItem Content="3"/>
+                                            <ComboBoxItem Content="4"/>
+                                            <ComboBoxItem Content="5"/>
+                                        </ComboBox>
+                                    </StackPanel>
+
+                                    <StackPanel Grid.Row="7" Margin="0,0,0,10">
+                                        <TextBlock Text="Preventiva Concluída" Style="{StaticResource LabelStyle}"/>
+                                        <ComboBox x:Name="PrevClosedCountCombo" SelectionChanged="FiltersChanged" SelectedIndex="0">
                                             <ComboBoxItem Content="Todas"/>
                                             <ComboBoxItem Content="1"/>
                                             <ComboBoxItem Content="2"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -143,6 +143,7 @@ namespace ManutMap
             PrazoDiasTextBox.PreviewTextInput += PrazoDiasTextBox_PreviewTextInput;
             TipoPrazoCombo.SelectionChanged += FiltersChanged;
             PrevCountRotaCombo.SelectionChanged += FiltersChanged;
+            PrevClosedCountCombo.SelectionChanged += FiltersChanged;
         }
 
         private void LoadLocalAndPopulate()
@@ -323,6 +324,7 @@ namespace ManutMap
                 Regional = (RegionalFilterCombo.SelectedItem as ComboBoxItem)?.Content.ToString() ?? "Todos",
                 Rota = (RotaFilterCombo.SelectedItem as ComboBoxItem)?.Content.ToString() ?? "Todos",
                 PreventivasPorRota = int.TryParse((PrevCountRotaCombo.SelectedItem as ComboBoxItem)?.Content.ToString(), out var pc) ? pc : 0,
+                PreventivasConcluidasPorRota = int.TryParse((PrevClosedCountCombo.SelectedItem as ComboBoxItem)?.Content.ToString(), out var pcc) ? pcc : 0,
                 StartDate = StartDatePicker.SelectedDate,
                 EndDate = EndDatePicker.SelectedDate,
                 ShowOpen = ChbOpen.IsChecked == true,
@@ -744,6 +746,7 @@ namespace ManutMap
             PrazoDiasTextBox.Text = string.Empty;
             TipoPrazoCombo.SelectedIndex = 0;
             PrevCountRotaCombo.SelectedIndex = 0;
+            PrevClosedCountCombo.SelectedIndex = 0;
 
             ApplyFilters();
         }

--- a/Models/FilterCriteria.cs
+++ b/Models/FilterCriteria.cs
@@ -14,6 +14,9 @@ namespace ManutMap.Models
         // Quantidade de preventivas por rota (0 = todas)
         public int PreventivasPorRota { get; set; }
 
+        // Quantidade de preventivas concluídas por rota (0 = todas)
+        public int PreventivasConcluidasPorRota { get; set; }
+
         public DateTime? StartDate { get; set; }
         public DateTime? EndDate { get; set; }
 

--- a/Services/FilterService.cs
+++ b/Services/FilterService.cs
@@ -156,6 +156,33 @@ namespace ManutMap.Services
                     .ToList();
             }
 
+            if (c.PreventivasConcluidasPorRota > 0)
+            {
+                filtered = filtered
+                    .Where(o =>
+                    {
+                        var tipo = (o["TIPO"]?.ToString() ?? string.Empty).Trim();
+                        if (!string.Equals(tipo, "PREVENTIVA", StringComparison.OrdinalIgnoreCase))
+                            return false;
+
+                        var dtCon = o["DTCONCLUSAO"]?.ToString();
+                        bool isClosed = !string.IsNullOrWhiteSpace(dtCon);
+                        if (!isClosed)
+                            return false;
+
+                        var tipoCausa = o["TIPOCAUSA"]?.ToString() ?? string.Empty;
+                        var m = Regex.Match(tipoCausa, @"(\d+)\s*A$", RegexOptions.IgnoreCase);
+                        if (!m.Success)
+                            return false;
+
+                        if (int.TryParse(m.Groups[1].Value, out var num))
+                            return num == c.PreventivasConcluidasPorRota;
+
+                        return false;
+                    })
+                    .ToList();
+            }
+
             if (c.SingleClientMarker)
             {
                 filtered = filtered


### PR DESCRIPTION
## Summary
- extend `FilterCriteria` with `PreventivasConcluidasPorRota`
- expose new combo box for selecting concluded Preventiva count
- hook up new control in `MainWindow.xaml.cs`
- update `FilterService` to filter concluded Preventivas

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d4062e43483338ee6ef1e3aaf22d7