### PR TITLE
Show all open OS for client in popup

### DIFF
--- a/Helpers/MapHtmlHelper.cs
+++ b/Helpers/MapHtmlHelper.cs
@@ -111,8 +111,18 @@ namespace ManutMap.Helpers
         var prevDias = item.PREV_DIAS;
         var corrDias = item.CORR_DIAS;
 
-        var osField = item.NUMOS_LIST || item.NUMOS;
-        var osLabel = item.NUMOS_LIST ? 'OSs' : 'OS';
+        var allOs = item.ALL_OS || item.NUMOS_LIST || item.NUMOS;
+        var highlight = item.HIGHLIGHT_OS || '';
+        var osLabel = (item.ALL_OS || item.NUMOS_LIST) ? 'OSs' : 'OS';
+        var osField;
+        if(allOs && highlight){
+          var parts = allOs.split(/\s*,\s*/);
+          osField = parts.map(function(p){
+            return p === highlight ? '<b>'+p+'</b>' : p;
+          }).join(', ');
+        }else{
+          osField = allOs;
+        }
         var popup = '<b>'+osLabel+':</b> '+osField+'<br>'+
                     '<b>Cliente:</b> '+item.NOMECLIENTE+'<br>'+
                     '<b>Prev. abertas:</b> '+item.PREV_ABERTAS_CLIENTE+'<br>'+

--- a/MainWindow.MapMethods.cs
+++ b/MainWindow.MapMethods.cs
@@ -7,7 +7,7 @@ namespace ManutMap
 {
     public partial class MainWindow
     {
-        public void ShowClientOnMap(string idSigfi)
+        public void ShowClientOnMap(string idSigfi, string? highlightOs = null)
         {
             if (_manutList == null || string.IsNullOrWhiteSpace(idSigfi)) return;
 
@@ -15,8 +15,27 @@ namespace ManutMap
                 .OfType<JObject>()
                 .Where(o => string.Equals((o["IDSIGFI"]?.ToString() ?? string.Empty).Trim(),
                                         idSigfi.Trim(), StringComparison.OrdinalIgnoreCase))
+                .Where(o =>
+                {
+                    var rec = o["DTAHORARECLAMACAO"]?.ToString();
+                    var con = o["DTCONCLUSAO"]?.ToString();
+                    return !string.IsNullOrWhiteSpace(rec) && string.IsNullOrWhiteSpace(con);
+                })
                 .ToList();
             if (entries.Count == 0) return;
+
+            var osList = entries
+                .Select(o => (o["NUMOS"]?.ToString() ?? string.Empty).Trim())
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            foreach (var obj in entries)
+            {
+                obj["ALL_OS"] = string.Join(", ", osList);
+                if (!string.IsNullOrWhiteSpace(highlightOs))
+                    obj["HIGHLIGHT_OS"] = highlightOs;
+            }
 
             var criteria = GetCurrentCriteria();
             _mapService.SetClustering(false);

--- a/PrazoWindow.xaml
+++ b/PrazoWindow.xaml
@@ -227,7 +227,7 @@
                             <DataGridTemplateColumn Header="Mapa" Width="Auto">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
-                                        <Button Content="Mapa" Click="MapaCorretiva_Click" Tag="{Binding IdSigfi}" Style="{StaticResource LinkButtonStyle}"/>
+                                        <Button Content="Mapa" Click="MapaCorretiva_Click" Tag="{Binding}" Style="{StaticResource LinkButtonStyle}"/>
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>
@@ -246,7 +246,7 @@
                             <DataGridTemplateColumn Header="Mapa" Width="Auto">
                                 <DataGridTemplateColumn.CellTemplate>
                                     <DataTemplate>
-                                        <Button Content="Mapa" Click="MapaPreventiva_Click" Tag="{Binding IdSigfi}" Style="{StaticResource LinkButtonStyle}"/>
+                                        <Button Content="Mapa" Click="MapaPreventiva_Click" Tag="{Binding}" Style="{StaticResource LinkButtonStyle}"/>
                                     </DataTemplate>
                                 </DataGridTemplateColumn.CellTemplate>
                             </DataGridTemplateColumn>

--- a/PrazoWindow.xaml.cs
+++ b/PrazoWindow.xaml.cs
@@ -150,18 +150,18 @@ namespace ManutMap
 
         private void MapaCorretiva_Click(object sender, RoutedEventArgs e)
         {
-            if (sender is Button btn && btn.Tag is string id && Owner is MainWindow mw)
+            if (sender is Button btn && btn.Tag is CorretivaInfo info && Owner is MainWindow mw)
             {
-                mw.ShowClientOnMap(id);
+                mw.ShowClientOnMap(info.IdSigfi, info.NumOS);
                 mw.Activate();
             }
         }
 
         private void MapaPreventiva_Click(object sender, RoutedEventArgs e)
         {
-            if (sender is Button btn && btn.Tag is string id && Owner is MainWindow mw)
+            if (sender is Button btn && btn.Tag is PreventivaInfo info && Owner is MainWindow mw)
             {
-                mw.ShowClientOnMap(id);
+                mw.ShowClientOnMap(info.IdSigfi, info.NumOS);
                 mw.Activate();
             }
         }


### PR DESCRIPTION
## Summary
- pass full row object to Map buttons so we know which OS was clicked
- send highlight and list info to map when showing a client
- display all OS numbers in popup and highlight the selected one

## Testing
- `dotnet build ManutMap.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d43af04548333bc9d88361fa8a915