### PR TITLE
Fix version detection

### DIFF
--- a/AssemblyInfo.cs
+++ b/AssemblyInfo.cs
@@ -7,5 +7,7 @@ using System.Windows;
                                                 // or application resource dictionaries)
     ResourceDictionaryLocation.SourceAssembly   //where the generic resource dictionary is located
                                                 //(used if a resource is not found in the page,
-                                                // app, or any theme specific resource dictionaries)
-)]
+                                                // app, or any theme specific resource dictionaries))]
+
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/ManutMap.csproj
+++ b/ManutMap.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
-	<PropertyGroup>
-		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0-windows</TargetFramework>
-		<UseWPF>true</UseWPF>
-		<ApplicationIcon>ChatGPT-Image-3-de-jul.-de-2025_-09_07_24.ico</ApplicationIcon>
-	</PropertyGroup>
+        <PropertyGroup>
+                <OutputType>WinExe</OutputType>
+                <TargetFramework>net8.0-windows</TargetFramework>
+                <UseWPF>true</UseWPF>
+                <ApplicationIcon>ChatGPT-Image-3-de-jul.-de-2025_-09_07_24.ico</ApplicationIcon>
+                <Version>1.0.0</Version>
+        </PropertyGroup>
 
         <ItemGroup>
                 <Compile Include="Services/FileService.cs" />

--- a/Services/AtualizadorService.cs
+++ b/Services/AtualizadorService.cs
@@ -16,7 +16,8 @@ namespace ManutMap.Services
 
         public async Task<(Version LocalVersion, Version RemoteVersion)> GetVersionsAsync()
         {
-            Version localVer = new Version(0, 0, 0, 0);
+            Version localVer = Assembly.GetExecutingAssembly().GetName().Version ?? new Version(0, 0, 0, 0);
+
             var dllPath = Path.Combine(InstallDir, "ManutMap.dll");
             var exePath = Path.Combine(InstallDir, "ManutMap.exe");
             string asmPath = File.Exists(dllPath) ? dllPath : exePath;
@@ -40,7 +41,11 @@ namespace ManutMap.Services
                 http.DefaultRequestHeaders.Add("User-Agent", "ManutMap");
                 var json = await http.GetStringAsync(ApiUrl);
                 var obj = JObject.Parse(json);
-                remoteVer = new Version(((string)obj["tag_name"]).TrimStart('v'));
+                var tag = ((string?)obj["tag_name"])?.TrimStart('v');
+                if (tag != null && Version.TryParse(tag, out var parsed))
+                {
+                    remoteVer = parsed;
+                }
             }
             catch
             {


### PR DESCRIPTION
## Summary
- add assembly version attributes
- set app version in the project
- detect current version from executing assembly
- parse GitHub tag more defensively

## Testing
- `dotnet build -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eb570e1088333b250b6fd3d1491b5