### PR TITLE
Fix version detection

### DIFF
--- a/ManutMap.csproj
+++ b/ManutMap.csproj
@@ -1,10 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
-	<PropertyGroup>
-		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0-windows</TargetFramework>
-		<UseWPF>true</UseWPF>
-		<ApplicationIcon>ChatGPT-Image-3-de-jul.-de-2025_-09_07_24.ico</ApplicationIcon>
-	</PropertyGroup>
+        <PropertyGroup>
+                <OutputType>WinExe</OutputType>
+                <TargetFramework>net8.0-windows</TargetFramework>
+                <UseWPF>true</UseWPF>
+                <ApplicationIcon>ChatGPT-Image-3-de-jul.-de-2025_-09_07_24.ico</ApplicationIcon>
+                <Version>1.0.0.1</Version>
+                <AssemblyVersion>1.0.0.1</AssemblyVersion>
+                <FileVersion>1.0.0.1</FileVersion>
+        </PropertyGroup>
 
         <ItemGroup>
                 <Compile Include="Services/FileService.cs" />

--- a/Services/AtualizadorService.cs
+++ b/Services/AtualizadorService.cs
@@ -17,19 +17,26 @@ namespace ManutMap.Services
         public async Task<(Version LocalVersion, Version RemoteVersion)> GetVersionsAsync()
         {
             Version localVer = new Version(0, 0, 0, 0);
-            var dllPath = Path.Combine(InstallDir, "ManutMap.dll");
-            var exePath = Path.Combine(InstallDir, "ManutMap.exe");
-            string asmPath = File.Exists(dllPath) ? dllPath : exePath;
-
-            if (File.Exists(asmPath))
+            try
             {
-                try
+                localVer = Assembly.GetExecutingAssembly().GetName().Version ?? localVer;
+            }
+            catch
+            {
+                // fallback to file lookup in caso de erro inesperado
+                var dllPath = Path.Combine(InstallDir, "ManutMap.dll");
+                var exePath = Path.Combine(InstallDir, "ManutMap.exe");
+                string asmPath = File.Exists(dllPath) ? dllPath : exePath;
+                if (File.Exists(asmPath))
                 {
-                    localVer = AssemblyName.GetAssemblyName(asmPath).Version;
-                }
-                catch (BadImageFormatException)
-                {
-                    // Executável não possui metadados. Mantém versão padrão.
+                    try
+                    {
+                        localVer = AssemblyName.GetAssemblyName(asmPath).Version;
+                    }
+                    catch (BadImageFormatException)
+                    {
+                        // Executável não possui metadados. Mantém versão padrão.
+                    }
                 }
             }
 
@@ -40,7 +47,10 @@ namespace ManutMap.Services
                 http.DefaultRequestHeaders.Add("User-Agent", "ManutMap");
                 var json = await http.GetStringAsync(ApiUrl);
                 var obj = JObject.Parse(json);
-                remoteVer = new Version(((string)obj["tag_name"]).TrimStart('v'));
+                var tag = ((string?)obj["tag_name"] ?? string.Empty).Trim();
+                tag = new string(tag.TrimStart('v').TakeWhile(c => char.IsDigit(c) || c == '.').ToArray());
+                if (Version.TryParse(tag, out var parsed))
+                    remoteVer = parsed;
             }
             catch
             {


### PR DESCRIPTION
## Summary
- add assembly version to project file
- improve version retrieval logic to read executing assembly and parse remote tags safely

## Testing
- `dotnet build ManutMap.csproj -v minimal` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686eb570e1088333b250b6fd3d1491b5