### PR TITLE
Atualiza botão de fechar na UpdateWindow

### DIFF
--- a/UpdateWindow.xaml
+++ b/UpdateWindow.xaml
@@ -29,6 +29,29 @@
                 </Setter.Value>
             </Setter>
         </Style>
+
+        <Style TargetType="Button" x:Key="RedButton">
+            <Setter Property="Background" Value="#D9534F"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="FontSize" Value="14"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="Height" Value="40"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="border" Background="{TemplateBinding Background}" CornerRadius="5">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="border" Property="Background" Value="#C9302C"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
     </Window.Resources>
 
     <Border Padding="35">
@@ -49,8 +72,8 @@
                     Style="{StaticResource ModernButton}"
                     Visibility="Collapsed"
                     Click="UpdateButton_Click"/>
-            <Button Content="Fechar"
-                    Style="{StaticResource ModernButton}"
+            <Button Content="Não Atualizar"
+                    Style="{StaticResource RedButton}"
                     Margin="0,10,0,0"
                     Click="CancelButton_Click"/>
         </StackPanel>


### PR DESCRIPTION
## Resumo
- adiciona `RedButton` style na `UpdateWindow`
- troca o texto do botão para `Não Atualizar` com estilo vermelho

## Testes
- `dotnet build ManutMap.sln -c Release` *(falhou: `dotnet` não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_686ebc9f2f1483339b1a879fca3da7b2