### PR TITLE
Fix update cancel closing app

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -18,6 +18,8 @@ namespace ManutMap
             Thread.CurrentThread.CurrentCulture = culture;
             Thread.CurrentThread.CurrentUICulture = culture;
 
+            ShutdownMode = ShutdownMode.OnExplicitShutdown;
+
             var updateWindow = new UpdateWindow();
             updateWindow.ShowDialog();
 
@@ -26,6 +28,8 @@ namespace ManutMap
                 var mainWindow = new MainWindow();
                 MainWindow = mainWindow;
                 mainWindow.Show();
+
+                ShutdownMode = ShutdownMode.OnMainWindowClose;
             }
             else
             {


### PR DESCRIPTION
## Summary
- prevent app shutdown when the update window closes
- reopen regular shutdown mode after showing the main window

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ebdb2ebb08333b0da4d70c3ef1d6b