### PR TITLE
Fix preventive deadline logic

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -560,19 +560,27 @@ namespace ManutMap
                 {
                     var proxima = dtCon.AddMonths(6);
                     int dias = (int)Math.Ceiling((proxima.Date - DateTime.Today).TotalDays);
-                    obj["PREV_ULTIMA"] = dtCon.ToString("yyyy-MM-dd");
-                    obj["PREV_PROXIMA"] = proxima.ToString("yyyy-MM-dd");
-                    obj["PREV_DIAS"] = dias;
-                    obj["ROTA_LAST"] = obj["ROTA"]?.ToString() ?? string.Empty;
+
+                    if (dias >= -60)
+                    {
+                        obj["PREV_ULTIMA"] = dtCon.ToString("yyyy-MM-dd");
+                        obj["PREV_PROXIMA"] = proxima.ToString("yyyy-MM-dd");
+                        obj["PREV_DIAS"] = dias;
+                        obj["ROTA_LAST"] = obj["ROTA"]?.ToString() ?? string.Empty;
+                    }
                 }
                 else if (prevDict.TryGetValue(id, out var info))
                 {
                     var proxima = info.dt.AddMonths(6);
                     int dias = (int)Math.Ceiling((proxima.Date - DateTime.Today).TotalDays);
-                    obj["PREV_ULTIMA"] = info.dt.ToString("yyyy-MM-dd");
-                    obj["PREV_PROXIMA"] = proxima.ToString("yyyy-MM-dd");
-                    obj["PREV_DIAS"] = dias;
-                    obj["ROTA_LAST"] = info.rota;
+
+                    if (dias >= -60)
+                    {
+                        obj["PREV_ULTIMA"] = info.dt.ToString("yyyy-MM-dd");
+                        obj["PREV_PROXIMA"] = proxima.ToString("yyyy-MM-dd");
+                        obj["PREV_DIAS"] = dias;
+                        obj["ROTA_LAST"] = info.rota;
+                    }
                 }
 
                 if (corrDict.TryGetValue(id, out var cdias))

--- a/PrazoWindow.xaml.cs
+++ b/PrazoWindow.xaml.cs
@@ -114,6 +114,10 @@ namespace ManutMap
             {
                 var proxima = kv.Value.dt.AddMonths(6);
                 int dias = (int)Math.Ceiling((proxima.Date - DateTime.Today).TotalDays);
+
+                // Ignore clients more than 60 days overdue
+                if (dias < -60) continue;
+
                 list.Add(new PreventivaInfo
                 {
                     NumOS = kv.Value.numOs,


### PR DESCRIPTION
## Summary
- ensure only the last preventive per client is considered
- skip clients with preventive overdue for more than 60 days

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687108e14ff483339a2504c5c58b4916