### PR TITLE
Fix preventive calculation per IdSigfi

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -514,7 +514,6 @@ namespace ManutMap
 
             foreach (var obj in _manutList.OfType<JObject>())
             {
-                string tipo = obj["TIPO"]?.ToString()?.Trim() ?? string.Empty;
                 string id = obj["IDSIGFI"]?.ToString()?.Trim();
                 if (string.IsNullOrEmpty(id))
                     id = obj["NOMECLIENTE"]?.ToString()?.Trim() ?? string.Empty;
@@ -546,30 +545,13 @@ namespace ManutMap
 
             foreach (var obj in _manutList.OfType<JObject>())
             {
-                string tipo = obj["TIPO"]?.ToString()?.Trim() ?? string.Empty;
                 string id = obj["IDSIGFI"]?.ToString()?.Trim();
                 if (string.IsNullOrEmpty(id))
                     id = obj["NOMECLIENTE"]?.ToString()?.Trim() ?? string.Empty;
                 if (string.IsNullOrEmpty(id))
                     continue;
 
-                var dtStr = obj["DTCONCLUSAO"]?.ToString();
-                if (string.Equals(tipo, "PREVENTIVA", StringComparison.OrdinalIgnoreCase) &&
-                    !string.IsNullOrWhiteSpace(dtStr) &&
-                    DateTime.TryParse(dtStr, pt, System.Globalization.DateTimeStyles.None, out var dtCon))
-                {
-                    var proxima = dtCon.AddMonths(6);
-                    int dias = (int)Math.Ceiling((proxima.Date - DateTime.Today).TotalDays);
-
-                    if (dias >= -60)
-                    {
-                        obj["PREV_ULTIMA"] = dtCon.ToString("yyyy-MM-dd");
-                        obj["PREV_PROXIMA"] = proxima.ToString("yyyy-MM-dd");
-                        obj["PREV_DIAS"] = dias;
-                        obj["ROTA_LAST"] = obj["ROTA"]?.ToString() ?? string.Empty;
-                    }
-                }
-                else if (prevDict.TryGetValue(id, out var info))
+                if (prevDict.TryGetValue(id, out var info))
                 {
                     var proxima = info.dt.AddMonths(6);
                     int dias = (int)Math.Ceiling((proxima.Date - DateTime.Today).TotalDays);


### PR DESCRIPTION
## Summary
- ensure last preventive date is applied per IdSigfi

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68710d54b0ec833384d692a87f75fd02