### PR TITLE
Improve employee search by matricula

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -388,6 +388,7 @@
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
 
                                     <StackPanel Grid.Row="1" Margin="0,0,0,10">
@@ -442,6 +443,17 @@
                                             <ComboBoxItem Content="4"/>
                                             <ComboBoxItem Content="5"/>
                                         </ComboBox>
+                                    </StackPanel>
+
+                                    <StackPanel Grid.Row="8" Margin="0,0,0,10">
+                                        <TextBlock Text="Funcionário" Style="{StaticResource LabelStyle}"/>
+                                        <StackPanel Orientation="Horizontal">
+                                            <ComboBox x:Name="FuncFieldCombo" Width="100" SelectionChanged="FiltersChanged" SelectedIndex="0" Margin="0,0,5,0">
+                                                <ComboBoxItem>Matricula</ComboBoxItem>
+                                                <ComboBoxItem>Nome</ComboBoxItem>
+                                            </ComboBox>
+                                            <TextBox x:Name="FuncSearchBox" Width="120" TextChanged="FiltersChanged"/>
+                                        </StackPanel>
                                     </StackPanel>
 
                                 </Grid>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -144,6 +144,8 @@ namespace ManutMap
             TipoPrazoCombo.SelectionChanged += FiltersChanged;
             PrevCountRotaCombo.SelectionChanged += FiltersChanged;
             PrevClosedCountCombo.SelectionChanged += FiltersChanged;
+            FuncFieldCombo.SelectionChanged += FiltersChanged;
+            FuncSearchBox.TextChanged += FiltersChanged;
         }
 
         private void LoadLocalAndPopulate()
@@ -343,7 +345,10 @@ namespace ManutMap
                 UseClusters = ChbCluster.IsChecked != false,
                 SingleClientMarker = ChbSingleClient.IsChecked == true,
                 PrazoDias = int.TryParse(PrazoDiasTextBox.Text, out var pd) ? pd : 0,
-                TipoPrazo = (TipoPrazoCombo.SelectedItem as ComboBoxItem)?.Content.ToString() ?? "Todos"
+                TipoPrazo = (TipoPrazoCombo.SelectedItem as ComboBoxItem)?.Content.ToString() ?? "Todos",
+                FuncionarioTermo = FuncSearchBox.Text.Trim(),
+                FuncionarioCampo = FuncFieldCombo.SelectedIndex,
+                FuncionarioMap = _funcMap
             };
         }
 
@@ -738,6 +743,9 @@ namespace ManutMap
             TipoPrazoCombo.SelectedIndex = 0;
             PrevCountRotaCombo.SelectedIndex = 0;
             PrevClosedCountCombo.SelectedIndex = 0;
+
+            FuncSearchBox.Text = string.Empty;
+            FuncFieldCombo.SelectedIndex = 0;
 
             ApplyFilters();
         }

--- a/Models/FilterCriteria.cs
+++ b/Models/FilterCriteria.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 
 namespace ManutMap.Models
 {
@@ -53,6 +54,13 @@ namespace ManutMap.Models
         // Filtro de prazos
         public int PrazoDias { get; set; }
         public string TipoPrazo { get; set; } = "Todos";
+
+        // Busca por funcionário
+        public string FuncionarioTermo { get; set; } = string.Empty;
+        // 0 = Matrícula, 1 = Nome
+        public int FuncionarioCampo { get; set; }
+
+        // Mapeamento matrícula -> nome
+        public Dictionary<string, string>? FuncionarioMap { get; set; }
     }
 }
-

--- a/Services/FilterService.cs
+++ b/Services/FilterService.cs
@@ -69,6 +69,47 @@ namespace ManutMap.Services
                             return false;
                     }
 
+                    if (!string.IsNullOrEmpty(c.FuncionarioTermo))
+                    {
+                        var desc = item["DESCADICIONALEXEC"]?.ToString() ?? string.Empty;
+                        if (c.FuncionarioCampo == 0)
+                        {
+                            bool ok = false;
+                            foreach (Match m in Regex.Matches(desc, "#(\\d+)"))
+                            {
+                                var mat = m.Groups[1].Value.TrimStart('0');
+                                if (mat.IndexOf(c.FuncionarioTermo.TrimStart('0'), StringComparison.OrdinalIgnoreCase) >= 0)
+                                {
+                                    ok = true;
+                                    break;
+                                }
+                            }
+                            if (!ok) return false;
+                        }
+                        else
+                        {
+                            bool ok = false;
+                            foreach (Match m in Regex.Matches(desc, "#(\\d+)"))
+                            {
+                                var mat = m.Groups[1].Value.TrimStart('0');
+                                if (c.FuncionarioMap != null && c.FuncionarioMap.TryGetValue(mat, out var nome))
+                                {
+                                    if (nome.IndexOf(c.FuncionarioTermo, StringComparison.OrdinalIgnoreCase) >= 0)
+                                    {
+                                        ok = true;
+                                        break;
+                                    }
+                                }
+                            }
+                            if (!ok)
+                            {
+                                var nomes = item["FUNCIONARIOS"]?.ToString() ?? string.Empty;
+                                if (nomes.IndexOf(c.FuncionarioTermo, StringComparison.OrdinalIgnoreCase) < 0)
+                                    return false;
+                            }
+                        }
+                    }
+
                     if (c.OnlyDatalog)
                     {
                         var tem = item["TEMDATALOG"]?.ToObject<bool>() ?? false;


### PR DESCRIPTION
## Summary
- enhance `FilterService` to map names back to matriculas when filtering
- pass `_funcMap` into filtering criteria
- extend `FilterCriteria` with a dictionary for the employee map

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687132134b8c8333bc224e9cb48e8c6f