### PR TITLE
Fix installation points display

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -314,6 +314,18 @@ namespace ManutMap
         private void FiltersChanged(object sender, RoutedEventArgs e)
         {
             if (_debounceTimer == null) return;
+            if (sender == ChbOnlyInst && ChbOnlyInst.IsChecked == true)
+            {
+                foreach (ComboBoxItem item in LatLonFieldCombo.Items)
+                {
+                    if ((item.Content?.ToString() ?? "") == "LATLONCONF")
+                    {
+                        if (LatLonFieldCombo.SelectedItem != item)
+                            LatLonFieldCombo.SelectedItem = item;
+                        break;
+                    }
+                }
+            }
             _debounceTimer.Stop();
             _debounceTimer.Start();
         }
@@ -348,7 +360,10 @@ namespace ManutMap
                 ColorServicoPreventiva = (ColorTipoPrevCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#0000FF",
                 ColorServicoCorretiva = (ColorTipoCorrCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#FFA500",
                 ColorServicoOutros = (ColorTipoServCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#008080",
-                LatLonField = (LatLonFieldCombo.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? "LATLON",
+                LatLonField =
+                    ChbOnlyInst.IsChecked == true
+                        ? "LATLONCONF"
+                        : (LatLonFieldCombo.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? "LATLON",
                 MarkerStyle = (MarkerStyleCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "circle",
                 OnlyDatalog = ChbOnlyDatalog.IsChecked == true,
                 OnlyInstalacao = ChbOnlyInst.IsChecked == true,


### PR DESCRIPTION
## Summary
- ensure installation markers use confirmed coordinates when filtering
- update FiltersChanged to switch coordinate field automatically when enabling installation-only filter

## Testing
- `dotnet build ManutMap.sln -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878fd476b208333bdd1cd698749fff0