### PR TITLE
Add highlight and custom behavior for installation filter

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -107,6 +107,17 @@
                 </Trigger>
             </Style.Triggers>
         </Style>
+        <Style x:Key="HighlightCheckBox" TargetType="CheckBox">
+            <Setter Property="Margin" Value="0,10,0,0"/>
+            <Setter Property="Padding" Value="5"/>
+            <Setter Property="FontWeight" Value="Bold"/>
+            <Style.Triggers>
+                <Trigger Property="IsChecked" Value="True">
+                    <Setter Property="Background" Value="{StaticResource BrandBlue}"/>
+                    <Setter Property="Foreground" Value="White"/>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
 
         <Style x:Key="Card" TargetType="Border">
             <Setter Property="Background" Value="{StaticResource Background.Panel}"/>
@@ -510,7 +521,7 @@
                                     <CheckBox x:Name="ChbOpen" Content="Exibir OS Abertas" IsChecked="True" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
                                     <CheckBox x:Name="ChbClosed" Content="Exibir OS Concluídas" IsChecked="True" Checked="FiltersChanged" Unchecked="FiltersChanged" Margin="0,10,0,0"/>
                                     <CheckBox x:Name="ChbOnlyDatalog" Content="Apenas OS com Datalog" Checked="FiltersChanged" Unchecked="FiltersChanged" Margin="0,10,0,0"/>
-                                    <CheckBox x:Name="ChbOnlyInst" Content="Apenas Instalação" Margin="0,10,0,0" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
+                                    <CheckBox x:Name="ChbOnlyInst" Content="Apenas Instalação" Style="{StaticResource HighlightCheckBox}" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
                                     <CheckBox x:Name="ChbSingleClient" Content="Marcador único por cliente" Margin="0,10,0,0" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
                                     <CheckBox x:Name="ChbCluster" Content="Agrupar Marcadores" IsChecked="True" Margin="0,10,0,0" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
                                     <CheckBox x:Name="ChbColorPrev" Content="Colorir por Preventiva" Margin="0,10,0,0" Checked="FiltersChanged" Unchecked="FiltersChanged"/>

--- a/Services/FilterService.cs
+++ b/Services/FilterService.cs
@@ -122,10 +122,24 @@ namespace ManutMap.Services
                         if (string.IsNullOrWhiteSpace(coord)) return false;
                     }
 
-                    var dtRec = item["DTAHORARECLAMACAO"]?.ToString();
-                    var dtCon = item["DTCONCLUSAO"]?.ToString();
-                    bool isOpen = !string.IsNullOrWhiteSpace(dtRec) && string.IsNullOrWhiteSpace(dtCon);
-                    bool isClosed = !string.IsNullOrWhiteSpace(dtCon);
+                    string dtRec = null;
+                    string dtCon;
+                    bool isOpen;
+                    bool isClosed;
+
+                    if (c.OnlyInstalacao)
+                    {
+                        dtCon = item["CONCLUSAO"]?.ToString();
+                        isOpen = false;
+                        isClosed = !string.IsNullOrWhiteSpace(dtCon);
+                    }
+                    else
+                    {
+                        dtRec = item["DTAHORARECLAMACAO"]?.ToString();
+                        dtCon = item["DTCONCLUSAO"]?.ToString();
+                        isOpen = !string.IsNullOrWhiteSpace(dtRec) && string.IsNullOrWhiteSpace(dtCon);
+                        isClosed = !string.IsNullOrWhiteSpace(dtCon);
+                    }
 
                     if (isOpen && !c.ShowOpen) return false;
                     if (isClosed && !c.ShowClosed) return false;
@@ -134,8 +148,13 @@ namespace ManutMap.Services
                     {
                         DateTime dt;
                         var pt = System.Globalization.CultureInfo.GetCultureInfo("pt-BR");
-                        if ((isOpen && DateTime.TryParse(dtRec, pt, System.Globalization.DateTimeStyles.None, out dt)) ||
-                            (isClosed && DateTime.TryParse(dtCon, pt, System.Globalization.DateTimeStyles.None, out dt)))
+                        bool parsed = false;
+                        if (isOpen && dtRec != null)
+                            parsed = DateTime.TryParse(dtRec, pt, System.Globalization.DateTimeStyles.None, out dt);
+                        else if (isClosed)
+                            parsed = DateTime.TryParse(dtCon, pt, System.Globalization.DateTimeStyles.None, out dt);
+
+                        if (parsed)
                         {
                             if (c.StartDate.HasValue && dt < c.StartDate.Value) return false;
                             if (c.EndDate.HasValue && dt > c.EndDate.Value) return false;


### PR DESCRIPTION
## Summary
- visually emphasize installation-only filter
- populate route filter from installation data when installation filter is active
- expose installation completion date to filtering logic
- adjust date filtering for installation mode

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878ff893a7c8333bb48ceac86e9cd31