### PR TITLE
Add Empresa combo filter for installations

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -400,6 +400,7 @@
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
                                         <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
 
                                     <StackPanel Grid.Row="1" Margin="0,0,0,10">
@@ -465,6 +466,11 @@
                                             </ComboBox>
                                             <TextBox x:Name="FuncSearchBox" Width="120" TextChanged="FiltersChanged"/>
                                         </StackPanel>
+                                    </StackPanel>
+
+                                    <StackPanel x:Name="EmpresaPanel" Grid.Row="9" Margin="0,0,0,10" Visibility="Collapsed">
+                                        <TextBlock Text="Empresa" Style="{StaticResource LabelStyle}"/>
+                                        <ComboBox x:Name="EmpresaFilterCombo" SelectionChanged="FiltersChanged"/>
                                     </StackPanel>
 
                                 </Grid>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -149,6 +149,7 @@ namespace ManutMap
             PrevClosedCountCombo.SelectionChanged += FiltersChanged;
             FuncFieldCombo.SelectionChanged += FiltersChanged;
             FuncSearchBox.TextChanged += FiltersChanged;
+            EmpresaFilterCombo.SelectionChanged += FiltersChanged;
         }
 
         private void LoadLocalAndPopulate()
@@ -254,6 +255,28 @@ namespace ManutMap
                 {
                     PopulateComboBox(RotaFilterCombo, "ROTA");
                 }
+            }
+            UpdateEmpresaCombo();
+        }
+
+        private void UpdateEmpresaCombo()
+        {
+            if (ChbOnlyInst.IsChecked == true)
+            {
+                var empresas = _instalList
+                    .OfType<JObject>()
+                    .Select(o => o["EMPRESA"]?.ToString()?.Trim())
+                    .Where(s => !string.IsNullOrEmpty(s))
+                    .Distinct();
+                PopulateComboBox(EmpresaFilterCombo, empresas);
+                EmpresaPanel.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                EmpresaPanel.Visibility = Visibility.Collapsed;
+                EmpresaFilterCombo.Items.Clear();
+                EmpresaFilterCombo.Items.Add(new ComboBoxItem { Content = "Todos" });
+                EmpresaFilterCombo.SelectedIndex = 0;
             }
         }
 
@@ -382,6 +405,7 @@ namespace ManutMap
                 IdSigfi = IdSigfiFilterBox.Text.Trim(),
                 Regional = (RegionalFilterCombo.SelectedItem as ComboBoxItem)?.Content.ToString() ?? "Todos",
                 Rota = (RotaFilterCombo.SelectedItem as ComboBoxItem)?.Content.ToString() ?? "Todos",
+                Empresa = (EmpresaFilterCombo.SelectedItem as ComboBoxItem)?.Content.ToString() ?? "Todos",
                 PreventivasPorRota = int.TryParse((PrevCountRotaCombo.SelectedItem as ComboBoxItem)?.Content.ToString(), out var pc) ? pc : 0,
                 PreventivasConcluidasPorRota = int.TryParse((PrevClosedCountCombo.SelectedItem as ComboBoxItem)?.Content.ToString(), out var pcc) ? pcc : 0,
                 StartDate = StartDatePicker.SelectedDate,
@@ -771,6 +795,7 @@ namespace ManutMap
             RegionalFilterCombo.SelectedIndex = 0;
             UpdateRotaCombo();
             RotaFilterCombo.SelectedIndex = 0;
+            EmpresaFilterCombo.SelectedIndex = 0;
 
             StartDatePicker.SelectedDate = null;
             EndDatePicker.SelectedDate = null;
@@ -1090,6 +1115,7 @@ namespace ManutMap
                     ["LATLONCONF"] = obj["LATLONCONF"],
                     ["ROTA"] = obj["ROTA"],
                     ["CONCLUSAO"] = obj["CONCLUSAO"],
+                    ["EMPRESA"] = obj["EMPRESA"],
                     ["TIPO"] = "INSTALACAO",
                     ["TIPODESIGFI"] = "INSTALACAO"
                 };

--- a/Models/FilterCriteria.cs
+++ b/Models/FilterCriteria.cs
@@ -11,6 +11,7 @@ namespace ManutMap.Models
         public string Regional { get; set; } = "Todos";
         public string Rota { get; set; } = "Todos";
         public string TipoServico { get; set; } = "Todos";
+        public string Empresa { get; set; } = "Todos";
 
         // Quantidade de preventivas por rota (0 = todas)
         public int PreventivasPorRota { get; set; }

--- a/Services/FilterService.cs
+++ b/Services/FilterService.cs
@@ -69,6 +69,13 @@ namespace ManutMap.Services
                             return false;
                     }
 
+                    if (c.Empresa != "Todos")
+                    {
+                        var emp = (item["EMPRESA"]?.ToString() ?? string.Empty).Trim();
+                        if (!emp.Equals(c.Empresa, StringComparison.OrdinalIgnoreCase))
+                            return false;
+                    }
+
                     if (!string.IsNullOrEmpty(c.FuncionarioTermo))
                     {
                         var desc = item["DESCADICIONALEXEC"]?.ToString() ?? string.Empty;


### PR DESCRIPTION
## Summary
- add `Empresa` field to `FilterCriteria`
- filter by `EMPRESA` in `FilterService`
- load EMPRESA values from installation JSON and show a combo box only when "Apenas Instalação" is checked
- update clear filters and criteria gathering

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687906d78db48333ae59be600f9a146f