### PR TITLE
Restrict datalog mapping to installation folders

### DIFF
--- a/Services/DatalogService.cs
+++ b/Services/DatalogService.cs
@@ -140,7 +140,12 @@ namespace ManutMap.Services
         {
             bool isInst = IsInstalacaoFolder(name);
 
+            // Always register the full folder name
             dict[name] = url;
+
+            // Only map OS identifiers when the folder represents an installation
+            if (!isInst)
+                return;
 
             string? osKey = null;
             var m = OsFullPrefixRegex.Match(name);
@@ -153,44 +158,25 @@ namespace ManutMap.Services
                     osKey = m.Groups[2].Value + m.Groups[1].Value;
             }
             if (!string.IsNullOrEmpty(osKey))
-            {
-                if (isInst)
-                    dict[osKey] = url;
-                else
-                    dict.TryAdd(osKey, url);
-            }
+                dict[osKey] = url;
 
             int idx = name.IndexOf('_');
             if (idx > 0)
             {
                 string prefix = name[..idx];
-                if (isInst)
-                    dict[prefix] = url;
-                else
-                    dict.TryAdd(prefix, url);
+                dict[prefix] = url;
 
                 if (idx == name.Length - 1)
                 {
                     string trimmed = prefix.TrimEnd('_');
-                    if (isInst)
-                        dict[trimmed] = url;
-                    else
-                        dict.TryAdd(trimmed, url);
+                    dict[trimmed] = url;
                 }
             }
 
             foreach (Match m2 in OsDigitsRegex.Matches(name))
             {
-                if (isInst)
-                {
-                    dict[m2.Value] = url;
-                    dict[m2.Groups[1].Value] = url;
-                }
-                else
-                {
-                    dict.TryAdd(m2.Value, url);
-                    dict.TryAdd(m2.Groups[1].Value, url);
-                }
+                dict[m2.Value] = url;
+                dict[m2.Groups[1].Value] = url;
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure OS links are created only for installation folders in `AddFolderKeys`

## Testing
- `dotnet build ManutMap.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68790a95a8a883339138119fe02e88d0