### PR TITLE
Fix installation datalog selection

### DIFF
--- a/Services/FilterService.cs
+++ b/Services/FilterService.cs
@@ -198,7 +198,19 @@ namespace ManutMap.Services
             filtered = filtered
                 .GroupBy(o => (o["NUMOS"]?.ToString() ?? string.Empty).Trim(),
                          StringComparer.OrdinalIgnoreCase)
-                .Select(g => g.First())
+                .Select(g =>
+                {
+                    if (c.OnlyInstalacao)
+                    {
+                        var inst = g.FirstOrDefault(o =>
+                            string.Equals(o["TIPO"]?.ToString()?.Trim(),
+                                          "INSTALACAO",
+                                          StringComparison.OrdinalIgnoreCase));
+                        if (inst != null)
+                            return inst;
+                    }
+                    return g.First();
+                })
                 .ToList();
 
             if (c.PreventivasPorRota > 0)


### PR DESCRIPTION
## Summary
- resolve wrong datalog link for installation markers by ensuring installation entries are chosen when deduplicating

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687911c4ffa8833388baa489eef74414