### PR TITLE
Improve datalog progress bar

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -62,6 +62,7 @@ namespace ManutMap
         private readonly DispatcherTimer _updateTimer;
         private bool _sidebarVisible = true;
         private int _foldersVisited = 0;
+        private int _totalFolders = 0;
 
         public MainWindow()
         {
@@ -342,33 +343,35 @@ namespace ManutMap
             _instalList = await _spService.DownloadInstalacaoJsonAsync();
             AppendInstalacaoData(_instalList);
 
+            progress?.Report((15, "Calculando pastas..."));
+
+            _totalFolders = await _datalogService.CountAllDatalogFoldersAsync();
             _foldersVisited = 0;
+
             var folderProgress = new Progress<int>(n =>
             {
                 _foldersVisited += n;
                 UpdateFolderProgress(_foldersVisited);
+                if (_totalFolders > 0)
+                {
+                    int percent = 15 + _foldersVisited * 75 / _totalFolders;
+                    progress?.Report((percent, "Sincronizando datalog..."));
+                }
             });
 
-            var subProgress = new Progress<(int Percent, string Message)>(p =>
-            {
-                int percent = 40 + p.Percent * 30 / 100;
-                progress?.Report((percent, $"Sincronizando datalog... {p.Message}"));
-                UpdateFolderProgress(_foldersVisited);
-            });
-
-            _datalogMap = await _datalogService.GetAllDatalogFoldersAsync(subProgress, folderProgress);
+            _datalogMap = await _datalogService.GetAllDatalogFoldersAsync(null, folderProgress);
             AnnotateDatalogInfo();
             AnnotatePrazoInfo();
             AnnotatePrevOpenCount();
             await AnnotateFuncionariosInfoAsync();
 
-            progress?.Report((70, "Atualizando filtros..."));
+            progress?.Report((90, "Atualizando filtros..."));
             PopulateComboBox(SigfiFilterCombo, "TIPODESIGFI");
             PopulateComboBox(TipoFilterCombo, "TIPO");
             UpdateRotaCombo();
             PopulateComboBox(RegionalFilterCombo, _regionalRotas.Keys);
 
-            progress?.Report((85, "Aplicando filtros..."));
+            progress?.Report((95, "Aplicando filtros..."));
             ApplyFilters();
             LastUpdatedText.Text = _spService.LastUpdate.ToString("dd/MM/yyyy HH:mm");
             progress?.Report((100, "Concluído"));

--- a/Services/DatalogService.cs
+++ b/Services/DatalogService.cs
@@ -615,6 +615,19 @@ namespace ManutMap.Services
             return _folderCache!;
         }
 
+        public async Task<int> CountAllDatalogFoldersAsync()
+        {
+            var site = await _graph.Sites[$"{Domain}:/sites/{SitePath}"].GetAsync();
+            int total = 0;
+            foreach (var driveName in DriveDatalogAll)
+            {
+                string driveId = await GetDriveId(site.Id, driveName);
+                var folders = await GetAllRootFoldersAsync(driveId, driveName);
+                total += folders.Count;
+            }
+            return total;
+        }
+
 
         public async Task<Dictionary<string, string>> GetDatalogFoldersPeriodAsync(DateTime ini, DateTime fim)
         {


### PR DESCRIPTION
## Summary
- track total folders when syncing
- calculate progress percent based on visited folders

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879320a3bd08333921eb4da3a4645a7