### PR TITLE
Reduce folder enumeration for progress bar

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -348,6 +348,8 @@ namespace ManutMap
             progress?.Report((15, "Calculando pastas..."));
 
             _totalFolders = await _datalogService.CountAllDatalogFoldersAsync();
+            if (_totalFolders == 0)
+                _totalFolders = 1; // evita divisão por zero e permite avanço da barra
             _foldersVisited = 0;
 
             var folderProgress = new Progress<int>(n =>

--- a/Services/DatalogService.cs
+++ b/Services/DatalogService.cs
@@ -615,17 +615,10 @@ namespace ManutMap.Services
             return _folderCache!;
         }
 
-        public async Task<int> CountAllDatalogFoldersAsync()
+        public Task<int> CountAllDatalogFoldersAsync()
         {
-            var site = await _graph.Sites[$"{Domain}:/sites/{SitePath}"].GetAsync();
-            int total = 0;
-            foreach (var driveName in DriveDatalogAll)
-            {
-                string driveId = await GetDriveId(site.Id, driveName);
-                var folders = await GetAllRootFoldersAsync(driveId, driveName);
-                total += folders.Count;
-            }
-            return total;
+            LoadCache();
+            return Task.FromResult(_folderCache?.Count ?? 0);
         }
 
 


### PR DESCRIPTION
## Summary
- speed up progress bar by counting datalog folders from cache instead of making a full scan
- handle zero cached folders so progress still advances

## Testing
- `dotnet build -v q` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68793dae17208333997f862b92dea02f