### PR TITLE
Fix sync lock-up on exception

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -317,9 +317,23 @@ namespace ManutMap
                 UpdateProgress(p.Percent, p.Message);
             });
             ShowProgress();
-            await SyncAndRefresh(progress);
-            HideProgress();
-            SyncButton.IsEnabled = true;
+            try
+            {
+                await SyncAndRefresh(progress);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(
+                    "Erro ao sincronizar:\n" + ex.Message,
+                    "Erro",
+                    MessageBoxButton.OK,
+                    MessageBoxImage.Error);
+            }
+            finally
+            {
+                HideProgress();
+                SyncButton.IsEnabled = true;
+            }
         }
 
         private void ShowProgress()


### PR DESCRIPTION
## Summary
- handle exceptions thrown during sync so the progress bar disappears

## Testing
- `dotnet build ManutMap.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879507e3e6c83339a607160c6eee952