### PR TITLE
Ensure cache file is deleted before writing new version

### DIFF
--- a/Services/DatalogService.cs
+++ b/Services/DatalogService.cs
@@ -118,6 +118,20 @@ namespace ManutMap.Services
                 ["foldersInst"] = JObject.FromObject(_cacheInst),
                 ["foldersManut"] = JObject.FromObject(_cacheManut)
             };
+
+            if (File.Exists(CachePath))
+            {
+                try
+                {
+                    File.Delete(CachePath);
+                }
+                catch
+                {
+                    // Se a exclusão falhar continuamos a criar o novo arquivo,
+                    // pois File.WriteAllTextAsync irá sobrescrever o conteúdo.
+                }
+            }
+
             await File.WriteAllTextAsync(CachePath, obj.ToString());
         }
 


### PR DESCRIPTION
## Summary
- make `SaveCacheAsync` remove the existing cache file before creating a new one to ensure the data file is completely replaced

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68795690f1a083339d7e256a5ae55317