### PR TITLE
Handle minimal sync caching

### DIFF
--- a/Services/DatalogService.cs
+++ b/Services/DatalogService.cs
@@ -117,7 +117,8 @@ namespace ManutMap.Services
                 ["lastUpdateInst"] = _cacheDateInst,
                 ["lastUpdateManut"] = _cacheDateManut,
                 ["foldersInst"] = JObject.FromObject(_cacheInst),
-                ["foldersManut"] = JObject.FromObject(_cacheManut)
+                ["foldersManut"] = JObject.FromObject(_cacheManut),
+                ["folderCount"] = _cacheInst.Count + _cacheManut.Count
             };
 
             if (File.Exists(CachePath))
@@ -390,6 +391,7 @@ namespace ManutMap.Services
                         MergeFolders(name, url, isInst);
                         driveUpdated = true;
                         if (isInst) updatedInst = true; else updatedManut = true;
+                        await SaveCacheAsync();
                     }
                     if (driveUpdated)
                         await SaveCacheAsync();


### PR DESCRIPTION
## Summary
- persist folder count in datalog cache
- save cache file after each folder is processed

## Testing
- `dotnet build ManutMap/ManutMap.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68796624c80483339bce5216057c2e9e