### PR TITLE
Implement datalog color filter

### DIFF
--- a/Helpers/MapHtmlHelper.cs
+++ b/Helpers/MapHtmlHelper.cs
@@ -153,7 +153,7 @@ namespace ManutMap.Helpers
       }
     }
 
-    function addMarkersSelective(data, showOpen, showClosed, colorOpen, colorClosed, colorPrev, colorCorr, colorServ, doPrev, doCorr, doServ, latLonField){
+    function addMarkersSelective(data, showOpen, showClosed, colorOpen, colorClosed, colorPrev, colorCorr, colorServ, doPrev, doCorr, doServ, doDat, colorDat, latLonField){
       clearMarkers();
 
       data.forEach(function(item){
@@ -180,17 +180,18 @@ namespace ManutMap.Helpers
         if(isNaN(lat) || isNaN(lng)) return;
 
         var tipo = (item.TIPO || '').toString().trim().toLowerCase();
+        var temDat = item.TemDatalog || item.TEMDATALOG || false;
         var color = isOpen ? colorOpen : colorClosed;
         if(tipo === 'preventiva' && doPrev) color = colorPrev;
         else if(tipo === 'corretiva' && doCorr) color = colorCorr;
         else if(tipo !== 'preventiva' && tipo !== 'corretiva' && doServ) color = colorServ;
+        if(temDat && doDat) color = colorDat;
 
         var m = L.circleMarker([lat,lng],{
           radius:6, fillColor:color, color:'#fff', weight:1.2, fillOpacity:0.9
         });
         markerGroup.addLayer(m);
 
-        var temDat = item.TemDatalog || item.TEMDATALOG || false;
         var datUrl = item.FolderUrl || item.FOLDERURL || '';
         var descExec = item.DESCADICIONALEXEC || '';
         var prevUlt = item.PREV_ULTIMA ? fmtDate(item.PREV_ULTIMA) : "";
@@ -559,6 +560,8 @@ namespace ManutMap.Helpers
                                              bool colorPrevOn,
                                              bool colorCorrOn,
                                              bool colorServOn,
+                                             bool colorDatalogOn,
+                                             string colorDatalog,
                                              string latLonField,
                                              bool iconByTipo = false,
                                              string? customIcon = null,
@@ -572,7 +575,7 @@ namespace ManutMap.Helpers
             else if(iconByTipo)
                 call = $"addMarkersByTipoServicoIcon(data,{showOpen.ToString().ToLower()},{showClosed.ToString().ToLower()},'{latLonField}');";
             else
-                call = $"addMarkersSelective(data,{showOpen.ToString().ToLower()},{showClosed.ToString().ToLower()},'{colorOpen}','{colorClosed}','{colorPrev}','{colorCorr}','{colorServ}',{colorPrevOn.ToString().ToLower()},{colorCorrOn.ToString().ToLower()},{colorServOn.ToString().ToLower()},'{latLonField}');";
+                call = $"addMarkersSelective(data,{showOpen.ToString().ToLower()},{showClosed.ToString().ToLower()},'{colorOpen}','{colorClosed}','{colorPrev}','{colorCorr}','{colorServ}',{colorPrevOn.ToString().ToLower()},{colorCorrOn.ToString().ToLower()},{colorServOn.ToString().ToLower()},{colorDatalogOn.ToString().ToLower()},'{colorDatalog}','{latLonField}');";
             var script = $"<script>var data = {json};window.onload=function(){{setClustering({useClusters.ToString().ToLower()});{call}}}</script>";
             return baseHtml.Replace("</body></html>", script + "</body></html>");
         }

--- a/MainWindow.MapMethods.cs
+++ b/MainWindow.MapMethods.cs
@@ -50,6 +50,8 @@ namespace ManutMap
                                             criteria.ColorPrevOn,
                                             criteria.ColorCorrOn,
                                             criteria.ColorServOn,
+                                            criteria.ColorDatalogOn,
+                                            criteria.ColorDatalog,
                                             criteria.LatLonField);
         }
 
@@ -78,6 +80,8 @@ namespace ManutMap
                                             criteria.ColorPrevOn,
                                             criteria.ColorCorrOn,
                                             criteria.ColorServOn,
+                                            criteria.ColorDatalogOn,
+                                            criteria.ColorDatalog,
                                             criteria.LatLonField);
         }
     }

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -532,6 +532,7 @@
                                     <CheckBox x:Name="ChbColorPrev" Content="Colorir por Preventiva" Margin="0,10,0,0" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
                                     <CheckBox x:Name="ChbColorCorr" Content="Colorir por Corretiva" Margin="0,10,0,0" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
                                     <CheckBox x:Name="ChbColorServ" Content="Colorir por Serviços" Margin="0,10,0,0" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
+                                    <CheckBox x:Name="ChbColorDatalog" Content="Colorir Datalog" Margin="0,10,0,0" Checked="FiltersChanged" Unchecked="FiltersChanged"/>
 
                                     <Separator Margin="0,10,0,15"/>
 
@@ -593,6 +594,15 @@
                                         <TextBlock Text="Cor Serviços:" Style="{StaticResource LabelStyle}"/>
                                         <ComboBox x:Name="ColorTipoServCombo" SelectionChanged="FiltersChanged" Width="120">
                                             <ComboBoxItem Content="Teal" Tag="#008080" IsSelected="True"/>
+                                            <ComboBoxItem Content="Vermelho" Tag="#FF0000"/>
+                                            <ComboBoxItem Content="Verde" Tag="#008000"/>
+                                            <ComboBoxItem Content="Azul" Tag="#0000FF"/>
+                                        </ComboBox>
+                                    </StackPanel>
+                                    <StackPanel Margin="0,0,0,15">
+                                        <TextBlock Text="Cor Datalog:" Style="{StaticResource LabelStyle}"/>
+                                        <ComboBox x:Name="ColorDatalogCombo" SelectionChanged="FiltersChanged" Width="120">
+                                            <ComboBoxItem Content="Roxo" Tag="#800080" IsSelected="True"/>
                                             <ComboBoxItem Content="Vermelho" Tag="#FF0000"/>
                                             <ComboBoxItem Content="Verde" Tag="#008000"/>
                                             <ComboBoxItem Content="Azul" Tag="#0000FF"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -150,9 +150,12 @@ namespace ManutMap
             ChbColorCorr.Unchecked += FiltersChanged;
             ChbColorServ.Checked += FiltersChanged;
             ChbColorServ.Unchecked += FiltersChanged;
+            ChbColorDatalog.Checked += FiltersChanged;
+            ChbColorDatalog.Unchecked += FiltersChanged;
             ColorTipoPrevCombo.SelectionChanged += FiltersChanged;
             ColorTipoCorrCombo.SelectionChanged += FiltersChanged;
             ColorTipoServCombo.SelectionChanged += FiltersChanged;
+            ColorDatalogCombo.SelectionChanged += FiltersChanged;
             MarkerStyleCombo.SelectionChanged += FiltersChanged;
             ChbSingleClient.Checked += FiltersChanged;
             ChbSingleClient.Unchecked += FiltersChanged;
@@ -480,6 +483,8 @@ namespace ManutMap
                 ColorServicoPreventiva = (ColorTipoPrevCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#0000FF",
                 ColorServicoCorretiva = (ColorTipoCorrCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#FFA500",
                 ColorServicoOutros = (ColorTipoServCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#008080",
+                ColorDatalogOn = ChbColorDatalog.IsChecked == true,
+                ColorDatalog = (ColorDatalogCombo.SelectedItem as ComboBoxItem)?.Tag?.ToString() ?? "#800080",
                 LatLonField =
                     IsInstalacaoSelected()
                         ? "LATLONCONF"
@@ -527,6 +532,8 @@ namespace ManutMap
                                                 criteria.ColorPrevOn,
                                                 criteria.ColorCorrOn,
                                                 criteria.ColorServOn,
+                                                criteria.ColorDatalogOn,
+                                                criteria.ColorDatalog,
                                                 criteria.LatLonField);
             }
             else if (_iconUrls.TryGetValue(criteria.MarkerStyle, out var iconUrl))
@@ -550,6 +557,8 @@ namespace ManutMap
                                                 criteria.ColorPrevOn,
                                                 criteria.ColorCorrOn,
                                                 criteria.ColorServOn,
+                                                criteria.ColorDatalogOn,
+                                                criteria.ColorDatalog,
                                                 criteria.LatLonField);
             }
 
@@ -885,10 +894,12 @@ namespace ManutMap
             ChbColorPrev.IsChecked = false;
             ChbColorCorr.IsChecked = false;
             ChbColorServ.IsChecked = false;
+            ChbColorDatalog.IsChecked = false;
 
             ColorTipoPrevCombo.SelectedIndex = 0;
             ColorTipoCorrCombo.SelectedIndex = 0;
             ColorTipoServCombo.SelectedIndex = 0;
+            ColorDatalogCombo.SelectedIndex = 0;
 
             MarkerStyleCombo.SelectedIndex = 0;
             LatLonFieldCombo.SelectedIndex = 0;

--- a/Models/FilterCriteria.cs
+++ b/Models/FilterCriteria.cs
@@ -36,6 +36,10 @@ namespace ManutMap.Models
         public string ColorServicoCorretiva { get; set; } = "#FFA500";
         public string ColorServicoOutros { get; set; } = "#008080";
 
+        // Colorir itens com datalog
+        public bool ColorDatalogOn { get; set; }
+        public string ColorDatalog { get; set; } = "#800080";
+
         // NOVO: qual campo de coordenada usar
         // "LATLON" ou "LATLONCON"
         public string LatLonField { get; set; } = "LATLON";

--- a/Services/MapService.cs
+++ b/Services/MapService.cs
@@ -72,13 +72,16 @@ namespace ManutMap.Services
                                          bool colorPrevOn,
                                          bool colorCorrOn,
                                          bool colorServOn,
+                                         bool colorDatalogOn,
+                                         string colorDatalog,
                                          string latLonField = "LATLON")
         {
             var json = JsonConvert.SerializeObject(data);
             var script =
                 $"addMarkersSelective({json},{showOpen.ToString().ToLower()},{showClosed.ToString().ToLower()}," +
                 $"'{colorOpen}','{colorClosed}','{colorPrev}','{colorCorr}','{colorServ}'," +
-                $"{colorPrevOn.ToString().ToLower()},{colorCorrOn.ToString().ToLower()},{colorServOn.ToString().ToLower()},'{latLonField}');";
+                $"{colorPrevOn.ToString().ToLower()},{colorCorrOn.ToString().ToLower()},{colorServOn.ToString().ToLower()}," +
+                $"{colorDatalogOn.ToString().ToLower()},'{colorDatalog}','{latLonField}');";
 
             if (!_ready)
                 _pendingScripts.Add(script);


### PR DESCRIPTION
## Summary
- add option to color markers that contain datalog
- update map scripts and service to pass new parameters
- extend filter criteria and UI elements

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e47f4cf7c83338566e382d664a428